### PR TITLE
Correct non-overlapping query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.2] - 2020-05-21
+
+### Fixed
+- Correct behaviour of `eachoverlap` iterator for non-overlapping queries.
+
 ## [2.0.1] - 2020-05-21
 
 ### Changed
@@ -71,7 +76,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Code from Bio.jl.
 - Support for GFF3 and BigWig.
 
-[Unreleased]: https://github.com/BioJulia/GenomicFeatures.jl/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/BioJulia/GenomicFeatures.jl/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/BioJulia/GenomicFeatures.jl/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/BioJulia/GenomicFeatures.jl/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/BioJulia/GenomicFeatures.jl/compare/v1.0.4...v2.0.0
 [1.0.4]: https://github.com/BioJulia/GenomicFeatures.jl/compare/v1.0.3...v1.0.4

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenomicFeatures"
 uuid = "899a7d2d-5c61-547b-bef9-6698a8d05446"
 authors = ["Kenta Sato <bicycle1885@gmail.com>", "Ben J. Ward <benjward@protonmail.com>", "Ciarán O’Mara <CiaranOMara@utas.edu.au>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 BioGenerics = "47718e42-2ac5-11e9-14af-e5595289c2ea"

--- a/src/intervalcollection.jl
+++ b/src/intervalcollection.jl
@@ -289,12 +289,13 @@ end
 # Overlaps
 # --------
 
-function eachoverlap(a::IntervalCollection{T}, b::Interval; filter::F = true_cmp) where {F,T}
-    if haskey(a.trees, b.seqname)
-        return intersect(a.trees[b.seqname], b)
+function eachoverlap(a::IntervalCollection{T}, query::Interval; filter::F = true_cmp) where {F,T}
+    if haskey(a.trees, query.seqname)
+        return ICTreeIntervalIntersectionIterator{F,T}(filter, ICTreeIntersection{T}(), a.trees[query.seqname], query)
     end
 
-    return ICTreeIntervalIntersectionIterator{F,T}()
+    return ICTreeIntervalIntersectionIterator{F,T}(filter, ICTreeIntersection{T}(), ICTree{T}(), query)
+
 end
 
 function eachoverlap(a::IntervalCollection, b::IntervalCollection; filter = true_cmp)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -414,6 +414,9 @@ end #testset Constructor Conversions
         iter3 = eachoverlap(ic_a, intervals_b)
         iter4 = eachoverlap(ic_a, ic_b)
         @test collect(iter1) == collect(iter2) == collect(iter3) == collect(iter4)
+
+        # non-overlapping query
+        @test length(collect(eachoverlap(ic_a, Interval("X", 0, 0)))) == 0
     end
 end
 end #testset GenomicFeatures


### PR DESCRIPTION
This PR corrects the construction of an `ICTreeIntervalIntersectionIterator` without a tree to allow the return of an empty vector for a non-overlapping query. The `eachoverlap` method for trees returns an empty vector if there is no intersection, so this correction results in consistent behaviour.

https://github.com/BioJulia/IntervalTrees.jl/issues/54