### PR TITLE
Release/v3.0.0

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install Dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
+      - name: Instantiate
+        run: julia --project=benchmark/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Run Benchmarks
         run: julia -e "using BenchmarkCI; BenchmarkCI.judge()"
       - name: Post Results

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -10,12 +10,15 @@ on:
 
 jobs:
   Documenter:
+    runs-on: ubuntu-latest
     permissions:
       contents: write
-    name: Documentation
-    runs-on: ubuntu-latest
+      statuses: write
     steps:
       - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -21,3 +21,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+      - run: |
+          julia --project=docs -e '
+            using Documenter: DocMeta, doctest
+            using GenomicFeatures
+            DocMeta.setdocmeta!(GenomicFeatures, :DocTestSetup, :(using GenomicFeatures); recursive=true)
+            doctest(GenomicFeatures)'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenomicFeatures"
 uuid = "899a7d2d-5c61-547b-bef9-6698a8d05446"
 authors = ["Kenta Sato <bicycle1885@gmail.com>", "Sabrina J. Ward <sabrinajward@protonmail.com>", "Ciarán O’Mara <CiaranOMara@utas.edu.au>"]
-version = "2.1.0"
+version = "3.0.0"
 
 [deps]
 BioGenerics = "47718e42-2ac5-11e9-14af-e5595289c2ea"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ IntervalTrees = "524e6230-43b7-53ae-be76-1e9e4d08d11b"
 [compat]
 BioGenerics = "0.1"
 DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18"
-IntervalTrees = "1.0"
+IntervalTrees = "1.1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -21,4 +21,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Distributions", "Documenter", "Random", "Test"]
+test = ["Distributions", "Random", "Test"]

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -4,6 +4,3 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GenomicFeatures = "899a7d2d-5c61-547b-bef9-6698a8d05446"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-
-[compat]
-GenomicFeatures = "3"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -6,4 +6,4 @@ PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-GenomicFeatures = "2"
+GenomicFeatures = "3"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -30,20 +30,20 @@ let suite = SUITE["sort"] = BenchmarkGroup()
 end
 
 let suite = SUITE["insert"] = BenchmarkGroup()
-    suite["shorthand"] = @benchmarkable(IntervalCollection($intervals_sorted))
-    suite["type"] = @benchmarkable(IntervalCollection{Int}($intervals_sorted))
+    suite["shorthand"] = @benchmarkable(GenomicIntervalCollection($intervals_sorted))
+    suite["type"] = @benchmarkable(GenomicIntervalCollection{Int}($intervals_sorted))
 end
 
 let suite = SUITE["push"] = BenchmarkGroup()
-    suite["$(typeof(intervals))"] = @benchmarkable([push!(col, i) for i in $intervals], setup=(col=IntervalCollection{Int}()))
+    suite["$(typeof(intervals))"] = @benchmarkable([push!(col, i) for i in $intervals], setup=(col=GenomicIntervalCollection{Int}()))
 end
 
 let suite = SUITE["eachoverlap"] = BenchmarkGroup()
     intervals_a = intervals_sorted
     intervals_b = sort(random_intervals(SEQNAMES, 1000, N, SEED+1))
 
-    col_a = IntervalCollection(intervals_a)
-    col_b = IntervalCollection(intervals_b)
+    col_a = GenomicIntervalCollection(intervals_a)
+    col_b = GenomicIntervalCollection(intervals_b)
 
     As = [intervals_a, col_a]
     Bs = [intervals_b, col_b]

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -18,7 +18,7 @@ SUITE = BenchmarkGroup()
 
 let suite = SUITE["accessors"] = BenchmarkGroup()
     s0 = suite["$(typeof(intervals))"] = BenchmarkGroup()
-    s0["seqname"] = @benchmarkable(seqname.($intervals))
+    s0["groupname"] = @benchmarkable(groupname.($intervals))
     s0["leftposition"] = @benchmarkable(leftposition.($intervals))
     s0["rightposition"] = @benchmarkable(rightposition.($intervals))
     s0["strand"] = @benchmarkable(strand.($intervals))

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -1,7 +1,6 @@
 using Pkg
 
 Pkg.activate(@__DIR__)
-Pkg.instantiate()
 
 Pkg.status()
 

--- a/docs/src/man/intervals.md
+++ b/docs/src/man/intervals.md
@@ -90,7 +90,7 @@ Empty interval collections can be initialized, and intervals elements can be add
 ```@example
 using GenomicFeatures # hide
 # The type parameter (Nothing here) indicates the interval metadata type.
-col = IntervalCollection{Nothing}()
+col = IntervalCollection{Interval{Nothing}}()
 
 for i in 1:100:10000
     push!(col, Interval("chr1", i, i + 99))
@@ -138,7 +138,7 @@ selected = IntervalCollection([x for x in col if predicate(x)])
 
 # output
 
-IntervalCollection{Nothing} with 1 intervals:
+IntervalCollection{Interval{Nothing}} with 1 intervals:
   chr1:1-8  .  nothing
 ```
 

--- a/docs/src/man/intervals.md
+++ b/docs/src/man/intervals.md
@@ -11,7 +11,7 @@ Similarly when writing data, you should not have to reason about off-by-one erro
 The [`GenomicInterval`](@ref GenomicInterval) type is defined as
 ```julia
 struct GenomicInterval{T} <: IntervalTrees.AbstractInterval{Int64}
-    seqname::String
+    groupname::String
     first::Int64
     last::Int64
     strand::Strand
@@ -19,8 +19,9 @@ struct GenomicInterval{T} <: IntervalTrees.AbstractInterval{Int64}
 end
 ```
 
-The first three fields (`seqname`, `first`, and `last`) are mandatory arguments when constructing the [`GenomicInterval`](@ref GenomicInterval) object.
-The `seqname` field holds the sequence name associated with the interval.
+The first three fields (`groupname`, `first`, and `last`) are mandatory arguments when constructing the [`GenomicInterval`](@ref GenomicInterval) object.
+The `groupname` field holds the group name associated with the interval.
+In some cases the `groupname` may denote the chromosome.
 The `first` and `last` fields are the leftmost and rightmost positions of the interval, which can be accessed with [`leftposition`](@ref leftposition) and [`rightposition`](@ref rightposition) functions, respectively.
 
 The `strand` field can take four kinds of values listed in the next table:
@@ -38,7 +39,7 @@ The default strand and metadata value are `STRAND_BOTH` and `nothing`:
 ```jldoctest; setup = :(using GenomicFeatures)
 julia> GenomicInterval("chr1", 10000, 20000)
 GenomicInterval{Nothing}:
-  sequence name: chr1
+  group name: chr1
   leftmost position: 10000
   rightmost position: 20000
   strand: .
@@ -46,7 +47,7 @@ GenomicInterval{Nothing}:
 
 julia> GenomicInterval("chr1", 10000, 20000, '+')
 GenomicInterval{Nothing}:
-  sequence name: chr1
+  group name: chr1
   leftmost position: 10000
   rightmost position: 20000
   strand: +
@@ -57,13 +58,13 @@ The following example shows all accessor functions for the five fields:
 ```jldoctest; setup = :(using GenomicFeatures)
 julia> i = GenomicInterval("chr1", 10000, 20000, '+', "some annotation")
 GenomicInterval{String}:
-  sequence name: chr1
+  group name: chr1
   leftmost position: 10000
   rightmost position: 20000
   strand: +
   metadata: some annotation
 
-julia> seqname(i)
+julia> groupname(i)
 "chr1"
 
 julia> leftposition(i)

--- a/docs/src/man/intervals.md
+++ b/docs/src/man/intervals.md
@@ -104,7 +104,7 @@ col = IntervalCollection([Interval("chr1", i, i + 99) for i in 1:100:10000])
 
 # output
 
-IntervalCollection{Nothing} with 100 intervals:
+IntervalCollection{Interval{Nothing}} with 100 intervals:
   chr1:1-100  .  nothing
   chr1:101-200  .  nothing
   chr1:201-300  .  nothing

--- a/docs/src/man/intervals.md
+++ b/docs/src/man/intervals.md
@@ -2,15 +2,15 @@
 
 The `GenomicFeatures` module consists of tools for working efficiently with genomic intervals.
 
-## Interval Type
+## GenomicInterval Type
 
 Intervals in `GenomicFeatures` are consistent with ranges in Julia: *1-based and end-inclusive*.
 When data is read from formats with different representations (i.e. 0-based and/or end-exclusive) they are always converted automatically.
 Similarly when writing data, you should not have to reason about off-by-one errors due to format differences while using functionality provided in `GenomicFeatures`.
 
-The [`Interval`](@ref Interval) type is defined as
+The [`GenomicInterval`](@ref GenomicInterval) type is defined as
 ```julia
-struct Interval{T} <: IntervalTrees.AbstractInterval{Int64}
+struct GenomicInterval{T} <: IntervalTrees.AbstractInterval{Int64}
     seqname::String
     first::Int64
     last::Int64
@@ -19,7 +19,7 @@ struct Interval{T} <: IntervalTrees.AbstractInterval{Int64}
 end
 ```
 
-The first three fields (`seqname`, `first`, and `last`) are mandatory arguments when constructing the [`Interval`](@ref Interval) object.
+The first three fields (`seqname`, `first`, and `last`) are mandatory arguments when constructing the [`GenomicInterval`](@ref GenomicInterval) object.
 The `seqname` field holds the sequence name associated with the interval.
 The `first` and `last` fields are the leftmost and rightmost positions of the interval, which can be accessed with [`leftposition`](@ref leftposition) and [`rightposition`](@ref rightposition) functions, respectively.
 
@@ -32,20 +32,20 @@ The `strand` field can take four kinds of values listed in the next table:
 | `'-'`  | `STRAND_NEG`  | negative strand                   |
 | `'.'`  | `STRAND_BOTH` | non-strand-specific feature       |
 
-[`Interval`](@ref Interval) is parameterized on metadata type, which lets it efficiently and precisely be specialized to represent intervals from a variety of formats.
+[`GenomicInterval`](@ref GenomicInterval) is parameterized on metadata type, which lets it efficiently and precisely be specialized to represent intervals from a variety of formats.
 
 The default strand and metadata value are `STRAND_BOTH` and `nothing`:
 ```jldoctest; setup = :(using GenomicFeatures)
-julia> Interval("chr1", 10000, 20000)
-Interval{Nothing}:
+julia> GenomicInterval("chr1", 10000, 20000)
+GenomicInterval{Nothing}:
   sequence name: chr1
   leftmost position: 10000
   rightmost position: 20000
   strand: .
   metadata: nothing
 
-julia> Interval("chr1", 10000, 20000, '+')
-Interval{Nothing}:
+julia> GenomicInterval("chr1", 10000, 20000, '+')
+GenomicInterval{Nothing}:
   sequence name: chr1
   leftmost position: 10000
   rightmost position: 20000
@@ -55,8 +55,8 @@ Interval{Nothing}:
 
 The following example shows all accessor functions for the five fields:
 ```jldoctest; setup = :(using GenomicFeatures)
-julia> i = Interval("chr1", 10000, 20000, '+', "some annotation")
-Interval{String}:
+julia> i = GenomicInterval("chr1", 10000, 20000, '+', "some annotation")
+GenomicInterval{String}:
   sequence name: chr1
   leftmost position: 10000
   rightmost position: 20000
@@ -80,9 +80,9 @@ julia> metadata(i)
 ```
 
 
-## Collections of Intervals
+## Collections of GenomicIntervals
 
-Collections of intervals are represented using the [`IntervalCollection`](@ref IntervalCollection) type, which is a general purpose indexed container for intervals.
+Collections of intervals are represented using the [`GenomicIntervalCollection`](@ref GenomicIntervalCollection) type, which is a general purpose indexed container for intervals.
 It supports fast intersection operations as well as insertion, deletion, and sorted iteration.
 
 Empty interval collections can be initialized, and intervals elements can be added to the collection one-by-one using `push!`.
@@ -90,21 +90,21 @@ Empty interval collections can be initialized, and intervals elements can be add
 ```@example
 using GenomicFeatures # hide
 # The type parameter (Nothing here) indicates the interval metadata type.
-col = IntervalCollection{Interval{Nothing}}()
+col = GenomicIntervalCollection{GenomicInterval{Nothing}}()
 
 for i in 1:100:10000
-    push!(col, Interval("chr1", i, i + 99))
+    push!(col, GenomicInterval("chr1", i, i + 99))
 end
 ```
 
-Incrementally building an interval collection like this works, but [`IntervalCollection`](@ref IntervalCollection) also has a bulk insertion constructor that is able to build the indexed data structure extremely efficiently from a sorted vector of intervals.
+Incrementally building an interval collection like this works, but [`GenomicIntervalCollection`](@ref GenomicIntervalCollection) also has a bulk insertion constructor that is able to build the indexed data structure extremely efficiently from a sorted vector of intervals.
 
 ```jldoctest; setup = :(using GenomicFeatures), output = false
-col = IntervalCollection([Interval("chr1", i, i + 99) for i in 1:100:10000])
+col = GenomicIntervalCollection([GenomicInterval("chr1", i, i + 99) for i in 1:100:10000])
 
 # output
 
-IntervalCollection{Interval{Nothing}} with 100 intervals:
+GenomicIntervalCollection{GenomicInterval{Nothing}} with 100 intervals:
   chr1:1-100  .  nothing
   chr1:101-200  .  nothing
   chr1:201-300  .  nothing
@@ -117,7 +117,7 @@ IntervalCollection{Interval{Nothing}} with 100 intervals:
 
 ```
 
-Building [`IntervalCollection`](@ref IntervalCollection)s in one shot like this should be preferred when it's convenient or speed is an issue.
+Building [`GenomicIntervalCollection`](@ref GenomicIntervalCollection)s in one shot like this should be preferred when it's convenient or speed is an issue.
 
 ## Filtering
 
@@ -125,20 +125,20 @@ Below are some examples of filtering intervals.
 The examples take advantage of bulk insertion.
 ```jldoctest; setup = :(using GenomicFeatures), output = true
 intervals = [
-  Interval("chr1", 1, 8),
-  Interval("chr1", 4, 20),
-  Interval("chr1", 14, 27)]
+  GenomicInterval("chr1", 1, 8),
+  GenomicInterval("chr1", 4, 20),
+  GenomicInterval("chr1", 14, 27)]
 
-col = IntervalCollection(intervals)
+col = GenomicIntervalCollection(intervals)
 
 predicate(i) = isodd(leftposition(i))
 
-selected = IntervalCollection(Base.Iterators.filter(predicate, col))
-selected = IntervalCollection([x for x in col if predicate(x)])
+selected = GenomicIntervalCollection(Base.Iterators.filter(predicate, col))
+selected = GenomicIntervalCollection([x for x in col if predicate(x)])
 
 # output
 
-IntervalCollection{Interval{Nothing}} with 1 intervals:
+GenomicIntervalCollection{GenomicInterval{Nothing}} with 1 intervals:
   chr1:1-8  .  nothing
 ```
 

--- a/src/GenomicFeatures.jl
+++ b/src/GenomicFeatures.jl
@@ -17,6 +17,8 @@ export
     metadata,
     isoverlapping,
 
+    GenomicPosition,
+
     GenomicIntervalCollection,
     eachoverlap,
     coverage,
@@ -36,6 +38,7 @@ import Base.@propagate_inbounds
 
 include("strand.jl")
 include("interval.jl")
+include("position.jl")
 include("intervalcollection.jl")
 include("queue.jl")
 include("overlap.jl")

--- a/src/GenomicFeatures.jl
+++ b/src/GenomicFeatures.jl
@@ -59,4 +59,16 @@ function volume(interval::Interval)
 	return span(interval) * GenomicFeatures.metadata(interval)
 end
 
+"""
+Get the interval type.
+Overwrite to suggest stream element conversions during iteration.
+"""
+function intervaltype(::Type{I}) where {I<:Interval}
+    return I
+end
+
+function intervaltype(interval::T) where T
+    return intervaltype(T)
+end
+
 end # module

--- a/src/GenomicFeatures.jl
+++ b/src/GenomicFeatures.jl
@@ -9,7 +9,7 @@ export
     STRAND_NEG,
     STRAND_BOTH,
 
-    Interval,
+    GenomicInterval,
     seqname,
     leftposition,
     rightposition,
@@ -17,7 +17,7 @@ export
     metadata,
     isoverlapping,
 
-    IntervalCollection,
+    GenomicIntervalCollection,
     eachoverlap,
     coverage,
 	hasintersection,
@@ -42,20 +42,20 @@ include("overlap.jl")
 include("coverage.jl")
 
 """
-    span(interval::Interval)::Int
+    span(interval::GenomicInterval)::Int
 
 Get the span of `interval`.
 """
-function span(interval::Interval)
+function span(interval::GenomicInterval)
 	return length(leftposition(interval):rightposition(interval))
 end
 
 """
-    volume(interval::Interval)
+    volume(interval::GenomicInterval)
 
 Get the product of the `interval`'s span and metadata.
 """
-function volume(interval::Interval)
+function volume(interval::GenomicInterval)
 	return span(interval) * GenomicFeatures.metadata(interval)
 end
 
@@ -63,7 +63,7 @@ end
 Get the interval type.
 Overwrite to suggest stream element conversions during iteration.
 """
-function intervaltype(::Type{I}) where {I<:Interval}
+function intervaltype(::Type{I}) where {I<:GenomicInterval}
     return I
 end
 

--- a/src/GenomicFeatures.jl
+++ b/src/GenomicFeatures.jl
@@ -10,7 +10,7 @@ export
     STRAND_BOTH,
 
     GenomicInterval,
-	groupname,
+    groupname,
     seqname,
     leftposition,
     rightposition,
@@ -23,7 +23,7 @@ export
     GenomicIntervalCollection,
     eachoverlap,
     coverage,
-	hasintersection,
+    hasintersection,
 
     isfilled,
     hasseqname,

--- a/src/GenomicFeatures.jl
+++ b/src/GenomicFeatures.jl
@@ -40,6 +40,9 @@ abstract type AbstractGenomicInterval{T} <: IntervalTrees.AbstractInterval{Int64
 
 abstract type AbstractGenomicCollection{I} end
 
+const _IterableGenomicCollection{I} = Union{<:AbstractVector{I}, <:AbstractGenomicCollection{I}} where {I}
+const IterableGenomicCollection{I} = Union{<:_IterableGenomicCollection{I}, <:Base.Generator{<:_IterableGenomicCollection{I}, <:Any}} where {I}
+
 include("strand.jl")
 include("interval.jl")
 include("position.jl")

--- a/src/GenomicFeatures.jl
+++ b/src/GenomicFeatures.jl
@@ -42,20 +42,20 @@ include("overlap.jl")
 include("coverage.jl")
 
 """
-    span(interval::GenomicInterval)::Int
+    span(interval::AbstractGenomicInterval)::Int
 
 Get the span of `interval`.
 """
-function span(interval::GenomicInterval)
+function span(interval::AbstractGenomicInterval)
 	return length(leftposition(interval):rightposition(interval))
 end
 
 """
-    volume(interval::GenomicInterval)
+    volume(interval::AbstractGenomicInterval)
 
 Get the product of the `interval`'s span and metadata.
 """
-function volume(interval::GenomicInterval)
+function volume(interval::AbstractGenomicInterval)
 	return span(interval) * GenomicFeatures.metadata(interval)
 end
 
@@ -63,7 +63,7 @@ end
 Get the interval type.
 Overwrite to suggest stream element conversions during iteration.
 """
-function intervaltype(::Type{I}) where {I<:GenomicInterval}
+function intervaltype(::Type{I}) where {I<:AbstractGenomicInterval}
     return I
 end
 

--- a/src/GenomicFeatures.jl
+++ b/src/GenomicFeatures.jl
@@ -36,6 +36,10 @@ import DataStructures
 import IntervalTrees
 import Base.@propagate_inbounds
 
+abstract type AbstractGenomicInterval{T} <: IntervalTrees.AbstractInterval{Int64} end
+
+abstract type AbstractGenomicCollection{I} end
+
 include("strand.jl")
 include("interval.jl")
 include("position.jl")

--- a/src/GenomicFeatures.jl
+++ b/src/GenomicFeatures.jl
@@ -43,6 +43,10 @@ abstract type AbstractGenomicCollection{I} end
 const _IterableGenomicCollection{I} = Union{<:AbstractVector{I}, <:AbstractGenomicCollection{I}} where {I}
 const IterableGenomicCollection{I} = Union{<:_IterableGenomicCollection{I}, <:Base.Generator{<:_IterableGenomicCollection{I}, <:Any}} where {I}
 
+function Base.eltype(::Type{C}) where {I, C<:Base.Generator{<:_IterableGenomicCollection{I}, <:Any}}
+    return I
+end
+
 include("strand.jl")
 include("interval.jl")
 include("position.jl")

--- a/src/GenomicFeatures.jl
+++ b/src/GenomicFeatures.jl
@@ -100,4 +100,15 @@ function baseintervaltype(::I) where {I<:GenomicFeatures.AbstractGenomicInterval
 	return baseintervaltype(I)
 end
 
+"""
+Get the interval's metadata type.
+"""
+function metadatatype(interval::Type{I}) where {T, I<:GenomicFeatures.AbstractGenomicInterval{T}}
+    return T
+end
+
+function metadatatype(::I) where {T, I<:GenomicFeatures.AbstractGenomicInterval{T}} #TODO: consider loosening captured types to IntervalTrees.AbstractInterval.
+    return metadatatype(I)
+end
+
 end # module

--- a/src/GenomicFeatures.jl
+++ b/src/GenomicFeatures.jl
@@ -10,6 +10,7 @@ export
     STRAND_BOTH,
 
     GenomicInterval,
+	groupname,
     seqname,
     leftposition,
     rightposition,
@@ -26,12 +27,13 @@ export
 
     isfilled,
     hasseqname,
+    hasgroupname,
     hasleftposition,
     hasrightposition,
 
 	span
 
-import BioGenerics: BioGenerics, seqname, leftposition, rightposition, isoverlapping, isfilled, hasseqname, hasleftposition, hasrightposition, metadata
+import BioGenerics: BioGenerics, groupname, seqname, leftposition, rightposition, isoverlapping, isfilled, hasgroupname, hasseqname, hasleftposition, hasrightposition, metadata
 import DataStructures
 import IntervalTrees
 import Base.@propagate_inbounds

--- a/src/GenomicFeatures.jl
+++ b/src/GenomicFeatures.jl
@@ -87,4 +87,17 @@ function intervaltype(interval::T) where T
     return intervaltype(T)
 end
 
+"""
+Get the interval type without metadata.
+This query is useful when converting an interval's metadata or when implementing promotion rules.
+"""
+function baseintervaltype(::Type{I}) where {I<:GenomicFeatures.AbstractGenomicInterval} #TODO: consider loosening captured types to IntervalTrees.AbstractInterval.
+    tn = Base.typename(I)
+    return getproperty(tn.module, tn.name)
+end
+
+function baseintervaltype(::I) where {I<:GenomicFeatures.AbstractGenomicInterval} #TODO: consider loosening captured types to IntervalTrees.AbstractInterval.
+	return baseintervaltype(I)
+end
+
 end # module

--- a/src/coverage.jl
+++ b/src/coverage.jl
@@ -29,7 +29,7 @@ julia> intervals = [
            Interval("chr1", 14, 27)];
 
 julia> coverage(intervals)
-IntervalCollection{UInt32} with 5 intervals:
+IntervalCollection{Interval{UInt32}} with 5 intervals:
   chr1:1-3  .  1
   chr1:4-8  .  2
   chr1:9-13  .  1
@@ -119,7 +119,7 @@ end
 
 # Helper function for coverage. Process remaining interval end points after
 # all intervals have been read.
-function coverage_process_lasts_heap!(cov::IntervalCollection{UInt32}, current_coverage, coverage_seqname, coverage_first, lasts)
+function coverage_process_lasts_heap!(cov::IntervalCollection{Interval{UInt32}}, current_coverage, coverage_seqname, coverage_first, lasts)
     while !isempty(lasts)
         pos = DataStructures.heappop!(lasts)
         if pos == coverage_first - 1

--- a/src/coverage.jl
+++ b/src/coverage.jl
@@ -37,7 +37,7 @@ GenomicIntervalCollection{GenomicInterval{UInt32}} with 5 intervals:
   chr1:21-27  .  1
 ```
 """
-function coverage(stream, seqname_isless::Function=isless)
+function coverage(stream, groupname_isless::Function=isless)
     cov = GenomicIntervalCollection{UInt32}()
     lasts = Int64[]
 
@@ -47,20 +47,20 @@ function coverage(stream, seqname_isless::Function=isless)
     end
 
     current_coverage = 0
-    coverage_seqname = ""
+    coverage_groupname = ""
     coverage_first = 0
     last_interval_first = 0
     interval, stream_state = stream_next
     stream_next = iterate(stream, stream_state)
 
     while true
-        if seqname(interval) != coverage_seqname
-            coverage_process_lasts_heap!(cov, current_coverage, coverage_seqname, coverage_first, lasts)
-            if !(isempty(coverage_seqname) || seqname_isless(coverage_seqname, seqname(interval)))
+        if groupname(interval) != coverage_groupname
+            coverage_process_lasts_heap!(cov, current_coverage, coverage_groupname, coverage_first, lasts)
+            if !(isempty(coverage_groupname) || groupname_isless(coverage_groupname, groupname(interval)))
                 error("GenomicIntervals must be sorted to compute coverage.")
             end
 
-            coverage_seqname = seqname(interval)
+            coverage_groupname = groupname(interval)
             current_coverage = 0
             coverage_first = 0
             last_interval_first = 0
@@ -84,7 +84,7 @@ function coverage(stream, seqname_isless::Function=isless)
                 current_coverage -= 1
             else
                 @assert pos >= coverage_first
-                push!(cov, GenomicInterval{UInt32}(coverage_seqname, coverage_first, pos, STRAND_BOTH, current_coverage))
+                push!(cov, GenomicInterval{UInt32}(coverage_groupname, coverage_first, pos, STRAND_BOTH, current_coverage))
                 current_coverage -= 1
                 coverage_first = pos + 1
             end
@@ -96,7 +96,7 @@ function coverage(stream, seqname_isless::Function=isless)
                 current_coverage += 1
             else
                 if current_coverage > 0
-                    push!(cov, GenomicInterval{UInt32}(coverage_seqname, coverage_first, leftposition(interval) - 1, STRAND_BOTH, current_coverage))
+                    push!(cov, GenomicInterval{UInt32}(coverage_groupname, coverage_first, leftposition(interval) - 1, STRAND_BOTH, current_coverage))
                 end
                 current_coverage += 1
                 coverage_first = leftposition(interval)
@@ -112,20 +112,20 @@ function coverage(stream, seqname_isless::Function=isless)
         end
     end
 
-    coverage_process_lasts_heap!(cov, current_coverage, coverage_seqname, coverage_first, lasts)
+    coverage_process_lasts_heap!(cov, current_coverage, coverage_groupname, coverage_first, lasts)
 
     return cov
 end
 
 # Helper function for coverage. Process remaining interval end points after all intervals have been read.
-function coverage_process_lasts_heap!(cov::GenomicIntervalCollection{GenomicInterval{UInt32}}, current_coverage, coverage_seqname, coverage_first, lasts)
+function coverage_process_lasts_heap!(cov::GenomicIntervalCollection{GenomicInterval{UInt32}}, current_coverage, coverage_groupname, coverage_first, lasts)
     while !isempty(lasts)
         pos = DataStructures.heappop!(lasts)
         if pos == coverage_first - 1
             current_coverage -= 1
         else
             @assert pos >= coverage_first
-            push!(cov, GenomicInterval{UInt32}(coverage_seqname, coverage_first, pos, STRAND_BOTH, current_coverage))
+            push!(cov, GenomicInterval{UInt32}(coverage_groupname, coverage_first, pos, STRAND_BOTH, current_coverage))
             current_coverage -= 1
             coverage_first = pos + 1
         end

--- a/src/coverage.jl
+++ b/src/coverage.jl
@@ -9,7 +9,7 @@
 """
     coverage(intervals)
 
-Compute the coverage of a collection of intervals and return an `IntervalCollection` that contains run-length encoded coverage data.
+Compute the coverage of a collection of intervals and return an `GenomicIntervalCollection` that contains run-length encoded coverage data.
 
 For example, given intervals like:
 
@@ -24,12 +24,12 @@ This function would return a new set of disjoint intervals with annotated covera
 
 ```jldoctest
 julia> intervals = [
-           Interval("chr1", 1, 8),
-           Interval("chr1", 4, 20),
-           Interval("chr1", 14, 27)];
+           GenomicInterval("chr1", 1, 8),
+           GenomicInterval("chr1", 4, 20),
+           GenomicInterval("chr1", 14, 27)];
 
 julia> coverage(intervals)
-IntervalCollection{Interval{UInt32}} with 5 intervals:
+GenomicIntervalCollection{GenomicInterval{UInt32}} with 5 intervals:
   chr1:1-3  .  1
   chr1:4-8  .  2
   chr1:9-13  .  1
@@ -38,7 +38,7 @@ IntervalCollection{Interval{UInt32}} with 5 intervals:
 ```
 """
 function coverage(stream, seqname_isless::Function=isless)
-    cov = IntervalCollection{UInt32}()
+    cov = GenomicIntervalCollection{UInt32}()
     lasts = Int64[]
 
     stream_next = iterate(stream)
@@ -57,7 +57,7 @@ function coverage(stream, seqname_isless::Function=isless)
         if seqname(interval) != coverage_seqname
             coverage_process_lasts_heap!(cov, current_coverage, coverage_seqname, coverage_first, lasts)
             if !(isempty(coverage_seqname) || seqname_isless(coverage_seqname, seqname(interval)))
-                error("Intervals must be sorted to compute coverage.")
+                error("GenomicIntervals must be sorted to compute coverage.")
             end
 
             coverage_seqname = seqname(interval)
@@ -67,7 +67,7 @@ function coverage(stream, seqname_isless::Function=isless)
         end
 
         if leftposition(interval) < last_interval_first
-            error("Intervals must be sorted to compute coverage.")
+            error("GenomicIntervals must be sorted to compute coverage.")
         end
 
         if !isempty(lasts) && lasts[1] < leftposition(interval)
@@ -84,7 +84,7 @@ function coverage(stream, seqname_isless::Function=isless)
                 current_coverage -= 1
             else
                 @assert pos >= coverage_first
-                push!(cov, Interval{UInt32}(coverage_seqname, coverage_first, pos, STRAND_BOTH, current_coverage))
+                push!(cov, GenomicInterval{UInt32}(coverage_seqname, coverage_first, pos, STRAND_BOTH, current_coverage))
                 current_coverage -= 1
                 coverage_first = pos + 1
             end
@@ -96,7 +96,7 @@ function coverage(stream, seqname_isless::Function=isless)
                 current_coverage += 1
             else
                 if current_coverage > 0
-                    push!(cov, Interval{UInt32}(coverage_seqname, coverage_first, leftposition(interval) - 1, STRAND_BOTH, current_coverage))
+                    push!(cov, GenomicInterval{UInt32}(coverage_seqname, coverage_first, leftposition(interval) - 1, STRAND_BOTH, current_coverage))
                 end
                 current_coverage += 1
                 coverage_first = leftposition(interval)
@@ -117,16 +117,15 @@ function coverage(stream, seqname_isless::Function=isless)
     return cov
 end
 
-# Helper function for coverage. Process remaining interval end points after
-# all intervals have been read.
-function coverage_process_lasts_heap!(cov::IntervalCollection{Interval{UInt32}}, current_coverage, coverage_seqname, coverage_first, lasts)
+# Helper function for coverage. Process remaining interval end points after all intervals have been read.
+function coverage_process_lasts_heap!(cov::GenomicIntervalCollection{GenomicInterval{UInt32}}, current_coverage, coverage_seqname, coverage_first, lasts)
     while !isempty(lasts)
         pos = DataStructures.heappop!(lasts)
         if pos == coverage_first - 1
             current_coverage -= 1
         else
             @assert pos >= coverage_first
-            push!(cov, Interval{UInt32}(coverage_seqname, coverage_first, pos, STRAND_BOTH, current_coverage))
+            push!(cov, GenomicInterval{UInt32}(coverage_seqname, coverage_first, pos, STRAND_BOTH, current_coverage))
             current_coverage -= 1
             coverage_first = pos + 1
         end

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -150,19 +150,3 @@ function Base.show(io::IO, i::Interval)
           print(io, "  metadata: ", metadata(i) === nothing ? "nothing" : metadata(i))
     end
 end
-
-function metadatatype(::Type{T}) where T
-    return _metadatatype(eltype(T))
-end
-
-function metadatatype(x::Any)
-    return metadatatype(typeof(x))
-end
-
-function _metadatatype(::Type{Interval{T}}) where T
-    return T
-end
-
-function _metadatatype(::Type{T}) where T
-    return T
-end

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -144,7 +144,12 @@ end
 Return true if interval `a` entirely precedes `b`.
 """
 function precedes(a::AbstractGenomicInterval, b::AbstractGenomicInterval, groupname_isless::Function=isless)
-    return (rightposition(a) < leftposition(b) && groupname(a) == groupname(b)) || groupname_isless(groupname(a), groupname(b))::Bool
+
+    if groupname(a) != groupname(b)
+        return groupname_isless(groupname(a), groupname(b))::Bool
+    end
+
+    return rightposition(a) < leftposition(b)
 end
 
 function Base.:(==)(a::AbstractGenomicInterval, b::AbstractGenomicInterval)

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -6,8 +6,6 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-abstract type AbstractGenomicInterval{T} <: IntervalTrees.AbstractInterval{Int64} end
-
 """
     GenomicInterval{T} <: AbstractGenomicInterval{T}
 

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -81,6 +81,22 @@ end
 IntervalTrees.first(i::AbstractGenomicInterval) = leftposition(i)
 IntervalTrees.last(i::AbstractGenomicInterval) = rightposition(i)
 
+function Base.isless(a::AbstractGenomicInterval, b::AbstractGenomicInterval, seqname_isless::Function=isless)
+    if seqname(a) != seqname(b)
+        return seqname_isless(seqname(a), seqname(b))::Bool
+    end
+
+    if leftposition(a) != leftposition(b)
+        return leftposition(a) < leftposition(b)
+    end
+
+    if rightposition(a) != rightposition(b)
+        return rightposition(a) < rightposition(b)
+    end
+
+    return false
+end
+
 function Base.isless(a::GenomicInterval, b::GenomicInterval, seqname_isless::Function=isless)
     if seqname(a) != seqname(b)
         return seqname_isless(seqname(a), seqname(b))::Bool

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -48,38 +48,38 @@ function GenomicInterval{T}(data) :: GenomicInterval{T} where T
     return data #Note: the returned data is converted to GenomicInterval{T}.
 end
 
-function BioGenerics.seqname(i::GenomicInterval)
+function BioGenerics.seqname(i::AbstractGenomicInterval)
     return i.seqname
 end
 
-function BioGenerics.metadata(i::GenomicInterval)
+function BioGenerics.metadata(i::AbstractGenomicInterval)
     return i.metadata
 end
 
-function strand(i::GenomicInterval)
+function strand(i::AbstractGenomicInterval)
     return i.strand
 end
 
 """
-    leftposition(i::GenomicInterval)
+    leftposition(i::AbstractGenomicInterval)
 
 Return the leftmost position of `i`.
 """
-function BioGenerics.leftposition(i::GenomicInterval)
+function BioGenerics.leftposition(i::AbstractGenomicInterval)
     return i.first
 end
 
 """
-    rightposition(i::GenomicInterval)
+    rightposition(i::AbstractGenomicInterval)
 
 Return the rightmost position of `i`.
 """
-function BioGenerics.rightposition(i::GenomicInterval)
+function BioGenerics.rightposition(i::AbstractGenomicInterval)
     return i.last
 end
 
-IntervalTrees.first(i::GenomicInterval) = leftposition(i)
-IntervalTrees.last(i::GenomicInterval) = rightposition(i)
+IntervalTrees.first(i::AbstractGenomicInterval) = leftposition(i)
+IntervalTrees.last(i::AbstractGenomicInterval) = rightposition(i)
 
 function Base.isless(a::GenomicInterval, b::GenomicInterval, seqname_isless::Function=isless)
     if seqname(a) != seqname(b)
@@ -104,9 +104,9 @@ end
 """
 Check if two intervals are well ordered.
 
-`GenomicIntervals` are considered well ordered if seqname(a) <= seqname(b) and leftposition(a) <= leftposition(b).
+`AbstractGenomicInterval` are considered well ordered if seqname(a) <= seqname(b) and leftposition(a) <= leftposition(b).
 """
-function isordered(a::GenomicInterval, b::GenomicInterval, seqname_isless::Function=isless)
+function isordered(a::AbstractGenomicInterval, b::AbstractGenomicInterval, seqname_isless::Function=isless)
     if seqname(a) != seqname(b)
         return seqname_isless(seqname(a), seqname(b))::Bool
     end
@@ -121,7 +121,7 @@ end
 """
 Return true if interval `a` entirely precedes `b`.
 """
-function precedes(a::GenomicInterval, b::GenomicInterval, seqname_isless::Function=isless)
+function precedes(a::AbstractGenomicInterval, b::AbstractGenomicInterval, seqname_isless::Function=isless)
     return (rightposition(a) < leftposition(b) && seqname(a) == seqname(b)) || seqname_isless(seqname(a), seqname(b))::Bool
 end
 
@@ -134,7 +134,7 @@ function Base.:(==)(a::GenomicInterval, b::GenomicInterval)
 end
 
 "Return true if interval `a` overlaps interval `b`, with no consideration to strand"
-function BioGenerics.isoverlapping(a::GenomicInterval, b::GenomicInterval)
+function BioGenerics.isoverlapping(a::AbstractGenomicInterval, b::AbstractGenomicInterval)
     return leftposition(a) <= rightposition(b) &&
            leftposition(b) <= rightposition(a) &&
            seqname(a)      == seqname(b)

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -163,6 +163,18 @@ function BioGenerics.isoverlapping(a::AbstractGenomicInterval, b::AbstractGenomi
            seqname(a)      == seqname(b)
 end
 
+function Base.show(io::IO, i::AbstractGenomicInterval)
+    if get(io, :compact, false)
+        print(io, seqname(i), ":", leftposition(i), "-", rightposition(i), "  ", metadata(i) === nothing ? "nothing" : metadata(i))
+    else
+        println(io, summary(i), ':')
+        println(io, "  sequence name: ", seqname(i))
+        println(io, "  leftmost position: ", leftposition(i))
+        println(io, "  rightmost position: ", rightposition(i))
+          print(io, "  metadata: ", metadata(i) === nothing ? "nothing" : metadata(i))
+    end
+end
+
 function Base.show(io::IO, i::GenomicInterval)
     if get(io, :compact, false)
         print(io, seqname(i), ":", leftposition(i), "-", rightposition(i), "  ", strand(i), "  ", metadata(i) === nothing ? "nothing" : metadata(i))

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -50,6 +50,10 @@ function BioGenerics.seqname(i::AbstractGenomicInterval)
     return i.seqname
 end
 
+function BioGenerics.groupname(i::AbstractGenomicInterval)
+    return seqname(i)
+end
+
 function BioGenerics.metadata(i::AbstractGenomicInterval)
     return i.metadata
 end

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -125,6 +125,13 @@ function precedes(a::AbstractGenomicInterval, b::AbstractGenomicInterval, seqnam
     return (rightposition(a) < leftposition(b) && seqname(a) == seqname(b)) || seqname_isless(seqname(a), seqname(b))::Bool
 end
 
+function Base.:(==)(a::AbstractGenomicInterval, b::AbstractGenomicInterval)
+    return seqname(a)       == seqname(b) &&
+           leftposition(a)  == leftposition(b) &&
+           rightposition(a) == rightposition(b) &&
+           metadata(a)      == metadata(b)
+end
+
 function Base.:(==)(a::GenomicInterval, b::GenomicInterval)
     return seqname(a)       == seqname(b) &&
            leftposition(a)  == leftposition(b) &&

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -6,8 +6,10 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
+abstract type AbstractGenomicInterval{T} <: IntervalTrees.AbstractInterval{Int64} end
+
 """
-    GenomicInterval{T} <: IntervalTrees.AbstractInterval{Int64}
+    GenomicInterval{T} <: AbstractGenomicInterval{T}
 
 A genomic interval specifies interval with some associated metadata.
 The first three fields (`seqname`, `first`, and `last`) are mandatory arguments when constructing the [`Interval`](@ref Interval) object.
@@ -19,7 +21,7 @@ The first three fields (`seqname`, `first`, and `last`) are mandatory arguments 
 - `strand::Strand`: the [`strand`](@ref Strand).
 - `metadata::T`
 """
-struct GenomicInterval{T} <: IntervalTrees.AbstractInterval{Int64}
+struct GenomicInterval{T} <: AbstractGenomicInterval{T}
     seqname::String
     first::Int64
     last::Int64

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -10,29 +10,29 @@
     GenomicInterval{T} <: AbstractGenomicInterval{T}
 
 A genomic interval specifies interval with some associated metadata.
-The first three fields (`seqname`, `first`, and `last`) are mandatory arguments when constructing the [`Interval`](@ref Interval) object.
+The first three fields (`groupname`, `first`, and `last`) are mandatory arguments when constructing the [`Interval`](@ref Interval) object.
 
 # Fields
-- `seqname::String`: the sequence name associated with the interval.
+- `groupname::String`: the group name associated with the interval.
 - `first::Int64`: the leftmost position.
 - `last::Int64`: the rightmost position.
 - `strand::Strand`: the [`strand`](@ref Strand).
 - `metadata::T`
 """
 struct GenomicInterval{T} <: AbstractGenomicInterval{T}
-    seqname::String
+    groupname::String
     first::Int64
     last::Int64
     strand::Strand
     metadata::T
 end
 
-function GenomicInterval(seqname::AbstractString, first::Integer, last::Integer, strand::Union{Strand,Char}=STRAND_BOTH, metadata::T=nothing) where T
-    return GenomicInterval{T}(seqname, first, last, strand, metadata)
+function GenomicInterval(groupname::AbstractString, first::Integer, last::Integer, strand::Union{Strand,Char}=STRAND_BOTH, metadata::T=nothing) where T
+    return GenomicInterval{T}(groupname, first, last, strand, metadata)
 end
 
-function GenomicInterval(seqname::AbstractString, range::UnitRange{R}, strand::Union{Strand,Char}=STRAND_BOTH, metadata::T=nothing) where {T,R<:Integer}
-    return GenomicInterval{T}(seqname, first(range), last(range), strand, metadata)
+function GenomicInterval(groupname::AbstractString, range::UnitRange{R}, strand::Union{Strand,Char}=STRAND_BOTH, metadata::T=nothing) where {T,R<:Integer}
+    return GenomicInterval{T}(groupname, first(range), last(range), strand, metadata)
 end
 
 
@@ -46,12 +46,12 @@ function GenomicInterval{T}(data) :: GenomicInterval{T} where T
     return data #Note: the returned data is converted to GenomicInterval{T}.
 end
 
-function BioGenerics.seqname(i::AbstractGenomicInterval)
-    return i.seqname
+function BioGenerics.groupname(i::AbstractGenomicInterval)
+    return i.groupname
 end
 
-function BioGenerics.groupname(i::AbstractGenomicInterval)
-    return seqname(i)
+function BioGenerics.seqname(i::AbstractGenomicInterval)
+    return groupname(i)
 end
 
 function BioGenerics.metadata(i::AbstractGenomicInterval)
@@ -87,9 +87,9 @@ end
 IntervalTrees.first(i::AbstractGenomicInterval) = leftposition(i)
 IntervalTrees.last(i::AbstractGenomicInterval) = rightposition(i)
 
-function Base.isless(a::AbstractGenomicInterval, b::AbstractGenomicInterval, seqname_isless::Function=isless)
-    if seqname(a) != seqname(b)
-        return seqname_isless(seqname(a), seqname(b))::Bool
+function Base.isless(a::AbstractGenomicInterval, b::AbstractGenomicInterval, groupname_isless::Function=isless)
+    if groupname(a) != groupname(b)
+        return groupname_isless(groupname(a), groupname(b))::Bool
     end
 
     if leftposition(a) != leftposition(b)
@@ -103,9 +103,9 @@ function Base.isless(a::AbstractGenomicInterval, b::AbstractGenomicInterval, seq
     return false
 end
 
-function Base.isless(a::GenomicInterval, b::GenomicInterval, seqname_isless::Function=isless)
-    if seqname(a) != seqname(b)
-        return seqname_isless(seqname(a), seqname(b))::Bool
+function Base.isless(a::GenomicInterval, b::GenomicInterval, groupname_isless::Function=isless)
+    if groupname(a) != groupname(b)
+        return groupname_isless(groupname(a), groupname(b))::Bool
     end
 
     if leftposition(a) != leftposition(b)
@@ -126,11 +126,11 @@ end
 """
 Check if two intervals are well ordered.
 
-`AbstractGenomicInterval` are considered well ordered if seqname(a) <= seqname(b) and leftposition(a) <= leftposition(b).
+`AbstractGenomicInterval` are considered well ordered if groupname(a) <= groupname(b) and leftposition(a) <= leftposition(b).
 """
-function isordered(a::AbstractGenomicInterval, b::AbstractGenomicInterval, seqname_isless::Function=isless)
-    if seqname(a) != seqname(b)
-        return seqname_isless(seqname(a), seqname(b))::Bool
+function isordered(a::AbstractGenomicInterval, b::AbstractGenomicInterval, groupname_isless::Function=isless)
+    if groupname(a) != groupname(b)
+        return groupname_isless(groupname(a), groupname(b))::Bool
     end
 
     if leftposition(a) != leftposition(b)
@@ -143,19 +143,19 @@ end
 """
 Return true if interval `a` entirely precedes `b`.
 """
-function precedes(a::AbstractGenomicInterval, b::AbstractGenomicInterval, seqname_isless::Function=isless)
-    return (rightposition(a) < leftposition(b) && seqname(a) == seqname(b)) || seqname_isless(seqname(a), seqname(b))::Bool
+function precedes(a::AbstractGenomicInterval, b::AbstractGenomicInterval, groupname_isless::Function=isless)
+    return (rightposition(a) < leftposition(b) && groupname(a) == groupname(b)) || groupname_isless(groupname(a), groupname(b))::Bool
 end
 
 function Base.:(==)(a::AbstractGenomicInterval, b::AbstractGenomicInterval)
-    return seqname(a)       == seqname(b) &&
+    return groupname(a)     == groupname(b) &&
            leftposition(a)  == leftposition(b) &&
            rightposition(a) == rightposition(b) &&
            metadata(a)      == metadata(b)
 end
 
 function Base.:(==)(a::GenomicInterval, b::GenomicInterval)
-    return seqname(a)       == seqname(b) &&
+    return groupname(a)     == groupname(b) &&
            leftposition(a)  == leftposition(b) &&
            rightposition(a) == rightposition(b) &&
            strand(a)        == strand(b) &&
@@ -166,15 +166,15 @@ end
 function BioGenerics.isoverlapping(a::AbstractGenomicInterval, b::AbstractGenomicInterval)
     return leftposition(a) <= rightposition(b) &&
            leftposition(b) <= rightposition(a) &&
-           seqname(a)      == seqname(b)
+           groupname(a)    == groupname(b)
 end
 
 function Base.show(io::IO, i::AbstractGenomicInterval)
     if get(io, :compact, false)
-        print(io, seqname(i), ":", leftposition(i), "-", rightposition(i), "  ", metadata(i) === nothing ? "nothing" : metadata(i))
+        print(io, groupname(i), ":", leftposition(i), "-", rightposition(i), "  ", metadata(i) === nothing ? "nothing" : metadata(i))
     else
         println(io, summary(i), ':')
-        println(io, "  sequence name: ", seqname(i))
+        println(io, "  group name: ", groupname(i))
         println(io, "  leftmost position: ", leftposition(i))
         println(io, "  rightmost position: ", rightposition(i))
           print(io, "  metadata: ", metadata(i) === nothing ? "nothing" : metadata(i))
@@ -183,10 +183,10 @@ end
 
 function Base.show(io::IO, i::GenomicInterval)
     if get(io, :compact, false)
-        print(io, seqname(i), ":", leftposition(i), "-", rightposition(i), "  ", strand(i), "  ", metadata(i) === nothing ? "nothing" : metadata(i))
+        print(io, groupname(i), ":", leftposition(i), "-", rightposition(i), "  ", strand(i), "  ", metadata(i) === nothing ? "nothing" : metadata(i))
     else
         println(io, summary(i), ':')
-        println(io, "  sequence name: ", seqname(i))
+        println(io, "  group name: ", groupname(i))
         println(io, "  leftmost position: ", leftposition(i))
         println(io, "  rightmost position: ", rightposition(i))
         println(io, "  strand: ", strand(i))

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -1,4 +1,4 @@
-# Interval
+# GenomicInterval
 # ========
 #
 # Base interval types and utilities.
@@ -6,10 +6,10 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-# Note, just to be clear: this shadows IntervalTrees.Interval
 """
-    struct Interval{T} <: IntervalTrees.AbstractInterval{Int64}
+    GenomicInterval{T} <: IntervalTrees.AbstractInterval{Int64}
 
+A genomic interval specifies interval with some associated metadata.
 The first three fields (`seqname`, `first`, and `last`) are mandatory arguments when constructing the [`Interval`](@ref Interval) object.
 
 # Fields
@@ -19,7 +19,7 @@ The first three fields (`seqname`, `first`, and `last`) are mandatory arguments 
 - `strand::Strand`: the [`strand`](@ref Strand).
 - `metadata::T`
 """
-struct Interval{T} <: IntervalTrees.AbstractInterval{Int64}
+struct GenomicInterval{T} <: IntervalTrees.AbstractInterval{Int64}
     seqname::String
     first::Int64
     last::Int64
@@ -27,59 +27,59 @@ struct Interval{T} <: IntervalTrees.AbstractInterval{Int64}
     metadata::T
 end
 
-function Interval(seqname::AbstractString, first::Integer, last::Integer, strand::Union{Strand,Char}=STRAND_BOTH, metadata::T=nothing) where T
-    return Interval{T}(seqname, first, last, strand, metadata)
+function GenomicInterval(seqname::AbstractString, first::Integer, last::Integer, strand::Union{Strand,Char}=STRAND_BOTH, metadata::T=nothing) where T
+    return GenomicInterval{T}(seqname, first, last, strand, metadata)
 end
 
-function Interval(seqname::AbstractString, range::UnitRange{R}, strand::Union{Strand,Char}=STRAND_BOTH, metadata::T=nothing) where {T,R<:Integer}
-    return Interval{T}(seqname, first(range), last(range), strand, metadata)
+function GenomicInterval(seqname::AbstractString, range::UnitRange{R}, strand::Union{Strand,Char}=STRAND_BOTH, metadata::T=nothing) where {T,R<:Integer}
+    return GenomicInterval{T}(seqname, first(range), last(range), strand, metadata)
 end
 
 
 """
-    Interval{T}(data)
+    GenomicInterval{T}(data)
 
-The returned data is converted to Interval{T} if there is an implemented [`Base.convert`](https://docs.julialang.org/en/v1/base/base/#Base.convert) function for the type of data.
-This method provides a useful hook for converting custom types to Interval{T}.
+The returned data is converted to GenomicInterval{T} if there is an implemented [`Base.convert`](https://docs.julialang.org/en/v1/base/base/#Base.convert) function for the type of data.
+This method provides a useful hook for converting custom types to GenomicInterval{T}.
 """
-function Interval{T}(data) :: Interval{T} where T
-    return data #Note: the returned data is converted to Interval{T}.
+function GenomicInterval{T}(data) :: GenomicInterval{T} where T
+    return data #Note: the returned data is converted to GenomicInterval{T}.
 end
 
-function BioGenerics.seqname(i::Interval)
+function BioGenerics.seqname(i::GenomicInterval)
     return i.seqname
 end
 
-function BioGenerics.metadata(i::Interval)
+function BioGenerics.metadata(i::GenomicInterval)
     return i.metadata
 end
 
-function strand(i::Interval)
+function strand(i::GenomicInterval)
     return i.strand
 end
 
 """
-    leftposition(i::Interval)
+    leftposition(i::GenomicInterval)
 
 Return the leftmost position of `i`.
 """
-function BioGenerics.leftposition(i::Interval)
+function BioGenerics.leftposition(i::GenomicInterval)
     return i.first
 end
 
 """
-    rightposition(i::Interval)
+    rightposition(i::GenomicInterval)
 
 Return the rightmost position of `i`.
 """
-function BioGenerics.rightposition(i::Interval)
+function BioGenerics.rightposition(i::GenomicInterval)
     return i.last
 end
 
-IntervalTrees.first(i::Interval) = leftposition(i)
-IntervalTrees.last(i::Interval) = rightposition(i)
+IntervalTrees.first(i::GenomicInterval) = leftposition(i)
+IntervalTrees.last(i::GenomicInterval) = rightposition(i)
 
-function Base.isless(a::Interval, b::Interval, seqname_isless::Function=isless)
+function Base.isless(a::GenomicInterval, b::GenomicInterval, seqname_isless::Function=isless)
     if seqname(a) != seqname(b)
         return seqname_isless(seqname(a), seqname(b))::Bool
     end
@@ -102,9 +102,9 @@ end
 """
 Check if two intervals are well ordered.
 
-Intervals are considered well ordered if seqname(a) <= seqname(b) and leftposition(a) <= leftposition(b).
+`GenomicIntervals` are considered well ordered if seqname(a) <= seqname(b) and leftposition(a) <= leftposition(b).
 """
-function isordered(a::Interval, b::Interval, seqname_isless::Function=isless)
+function isordered(a::GenomicInterval, b::GenomicInterval, seqname_isless::Function=isless)
     if seqname(a) != seqname(b)
         return seqname_isless(seqname(a), seqname(b))::Bool
     end
@@ -119,11 +119,11 @@ end
 """
 Return true if interval `a` entirely precedes `b`.
 """
-function precedes(a::Interval, b::Interval, seqname_isless::Function=isless)
+function precedes(a::GenomicInterval, b::GenomicInterval, seqname_isless::Function=isless)
     return (rightposition(a) < leftposition(b) && seqname(a) == seqname(b)) || seqname_isless(seqname(a), seqname(b))::Bool
 end
 
-function Base.:(==)(a::Interval, b::Interval)
+function Base.:(==)(a::GenomicInterval, b::GenomicInterval)
     return seqname(a)       == seqname(b) &&
            leftposition(a)  == leftposition(b) &&
            rightposition(a) == rightposition(b) &&
@@ -132,13 +132,13 @@ function Base.:(==)(a::Interval, b::Interval)
 end
 
 "Return true if interval `a` overlaps interval `b`, with no consideration to strand"
-function BioGenerics.isoverlapping(a::Interval, b::Interval)
+function BioGenerics.isoverlapping(a::GenomicInterval, b::GenomicInterval)
     return leftposition(a) <= rightposition(b) &&
            leftposition(b) <= rightposition(a) &&
            seqname(a)      == seqname(b)
 end
 
-function Base.show(io::IO, i::Interval)
+function Base.show(io::IO, i::GenomicInterval)
     if get(io, :compact, false)
         print(io, seqname(i), ":", leftposition(i), "-", rightposition(i), "  ", strand(i), "  ", metadata(i) === nothing ? "nothing" : metadata(i))
     else

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -56,6 +56,10 @@ function BioGenerics.metadata(i::AbstractGenomicInterval)
     return i.metadata
 end
 
+function BioGenerics.metadata(i::AbstractGenomicInterval{Nothing})
+    return nothing
+end
+
 function strand(i::AbstractGenomicInterval)
     return i.strand
 end

--- a/src/intervalcollection.jl
+++ b/src/intervalcollection.jl
@@ -116,7 +116,7 @@ end
 Constructor that guesses metadatatype, and offers conversion through collection.
 """
 function IntervalCollection(data, sort::Bool=false)
-    return IntervalCollection(collect(Interval{metadatatype(data)}, data), sort)
+    return IntervalCollection(collect(intervaltype(eltype(data)), data), sort)
 end
 
 function update_ordered_trees!(ic::IntervalCollection{I}) where I
@@ -425,7 +425,7 @@ struct IntervalCollectionStreamIterator{F,S,Ib}
 end
 
 function Base.eltype(::Type{IntervalCollectionStreamIterator{F,S,Ib}}) where {F,S,Ib}
-    return Tuple{Interval{metadatatype(S)},Ib}
+    return Tuple{intervaltype(eltype(S)),Ib}
 end
 
 function Base.IteratorSize(::Type{IntervalCollectionStreamIterator{F,S,Ib}}) where {F,S,Ib}

--- a/src/intervalcollection.jl
+++ b/src/intervalcollection.jl
@@ -1,4 +1,4 @@
-# An IntervalCollection is an efficiently stored and indexed set of annotated genomic intervals.
+# A GenomicIntervalCollection is an efficiently stored and indexed set of annotated genomic intervals.
 # It looks something like this.
 #
 #                                      ┌─────┐
@@ -13,12 +13,12 @@
 #                     │ IntervalTree 1 │    │ IntervalTree 2 │
 #                     └────────────────┘    └────────────────┘
 #                              │
-#                    ┌─────────┴─────────────────────────┬────────────────────────┐
-#                    │                                   │                        │
-#                    ▼                                   ▼                        ▼
-#   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-#   ┃ Interval{T}(10000, 20000, ...) ┃  ┃ Interval{T}(35000, 40000, ...) ┃      ...
-#   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+#                    ┌─────────┴─────────────────────────┬────────────────────────────────────┐
+#                    │                                   │                                    │
+#                    ▼                                   ▼                                    ▼
+#   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+#   ┃ GenomicInterval{T}(10000, 20000, ...) ┃  ┃ GenomicInterval{T}(35000, 40000, ...) ┃      ...
+#   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 #
 #
 #
@@ -39,8 +39,8 @@ const ICTreeIntersection{I}                   = IntervalTrees.Intersection{Int64
 const ICTreeIntersectionIterator{F,Ia,Ib}     = IntervalTrees.IntersectionIterator{F,Int64,Ia,64,Ib,64}
 const ICTreeIntervalIntersectionIterator{F,I} = IntervalTrees.IntervalIntersectionIterator{F,Int64,I,64}
 
-"An IntervalCollection is an efficiently stored and indexed set of annotated genomic intervals."
-mutable struct IntervalCollection{I}
+"A GenomicIntervalCollection is an efficiently stored and indexed set of annotated genomic intervals."
+mutable struct GenomicIntervalCollection{I}
     # Sequence name mapped to IntervalTree, which in turn maps intervals to a list of metadata.
     trees::Dict{String,ICTree{I}}
 
@@ -53,22 +53,22 @@ mutable struct IntervalCollection{I}
     ordered_trees_outdated::Bool
 
     "Empty initialization."
-    function IntervalCollection{T}() where T
-        return IntervalCollection{Interval{T}}()
+    function GenomicIntervalCollection{T}() where T
+        return GenomicIntervalCollection{GenomicInterval{T}}()
     end
 
     # Longhand constructor.
-    function IntervalCollection{I}() where {I<:Interval}
+    function GenomicIntervalCollection{I}() where {I<:GenomicInterval}
         return new{I}(Dict{String,ICTree{I}}(), 0, ICTree{I}[], false)
     end
 
     "Bulk insertion."
-    function IntervalCollection{I}(intervals::AbstractVector{I}, sort::Bool=false) where {I<:Interval}
+    function GenomicIntervalCollection{I}(intervals::AbstractVector{I}, sort::Bool=false) where {I<:GenomicInterval}
         if sort
             sort!(intervals)
         else
             if !issorted(intervals)
-                error("Intervals must be sorted, or `sort=true` set, to construct an IntervalCollection")
+                error("GenomicIntervals must be sorted, or `sort=true` set, to construct an GenomicIntervalCollection")
             end
         end
 
@@ -88,38 +88,38 @@ mutable struct IntervalCollection{I}
 end
 
 """
-    IntervalCollection(intervals::AbstractVector{I}, sort::Bool=false) where {I<:Interval}
+    GenomicIntervalCollection(intervals::AbstractVector{I}, sort::Bool=false) where {I<:Interval}
 Shorthand constructor.
 """
-function IntervalCollection(intervals::AbstractVector{I}, sort::Bool=false) where {I<:Interval}
-    return IntervalCollection{I}(intervals, sort)
+function GenomicIntervalCollection(intervals::AbstractVector{I}, sort::Bool=false) where {I<:GenomicInterval}
+    return GenomicIntervalCollection{I}(intervals, sort)
 end
 
 """
-    IntervalCollection{T}(data, sort::Bool=true) where {T}
+    GenomicIntervalCollection{T}(data, sort::Bool=true) where {T}
 Shorthand for metadata type bulk insertion.
 """
-function IntervalCollection{T}(data, sort::Bool=true) where {T}
-    return IntervalCollection{Interval{T}}(collect(Interval{T}, data), sort)
+function GenomicIntervalCollection{T}(data, sort::Bool=true) where {T}
+    return GenomicIntervalCollection{GenomicInterval{T}}(collect(GenomicInterval{T}, data), sort)
 end
 
 """
-    IntervalCollection{I}(data, sort::Bool=false) where {I<:Interval}
+    GenomicIntervalCollection{I}(data, sort::Bool=false) where {I<:Interval}
 Constructor that offers conversion through collection.
 """
-function IntervalCollection{I}(data, sort::Bool=false) where {I<:Interval}
-    return IntervalCollection(collect(I, data), sort)
+function GenomicIntervalCollection{I}(data, sort::Bool=false) where {I<:GenomicInterval}
+    return GenomicIntervalCollection(collect(I, data), sort)
 end
 
 """
-    IntervalCollection(data, sort::Bool=false)
+    GenomicIntervalCollection(data, sort::Bool=false)
 Constructor that guesses metadatatype, and offers conversion through collection.
 """
-function IntervalCollection(data, sort::Bool=false)
-    return IntervalCollection(collect(intervaltype(eltype(data)), data), sort)
+function GenomicIntervalCollection(data, sort::Bool=false)
+    return GenomicIntervalCollection(collect(intervaltype(eltype(data)), data), sort)
 end
 
-function update_ordered_trees!(ic::IntervalCollection{I}) where I
+function update_ordered_trees!(ic::GenomicIntervalCollection{I}) where I
     if ic.ordered_trees_outdated
         ic.ordered_trees = collect(ICTree{I}, values(ic.trees))
         p = sortperm(collect(AbstractString, keys(ic.trees)), lt = isless)
@@ -128,7 +128,7 @@ function update_ordered_trees!(ic::IntervalCollection{I}) where I
     end
 end
 
-function Base.push!(ic::IntervalCollection{I}, i::I) where {I<:Interval}
+function Base.push!(ic::GenomicIntervalCollection{I}, i::I) where {I<:GenomicInterval}
     tree = get!(ic.trees, seqname(i)) do
         # Setup empty tree for new seqname key.
         ic.ordered_trees_outdated = true
@@ -139,9 +139,9 @@ function Base.push!(ic::IntervalCollection{I}, i::I) where {I<:Interval}
     return ic
 end
 
-function Base.show(io::IO, ic::IntervalCollection{I}) where I
+function Base.show(io::IO, ic::GenomicIntervalCollection{I}) where I
     n_entries = length(ic)
-    println(io, "IntervalCollection{$(I)} with $(n_entries) intervals:")
+    println(io, "GenomicIntervalCollection{$(I)} with $(n_entries) intervals:")
     if n_entries > 0
         for (k, i) in enumerate(ic)
             if k > 8
@@ -155,15 +155,16 @@ function Base.show(io::IO, ic::IntervalCollection{I}) where I
     end
 end
 
-function Base.length(ic::IntervalCollection)
+function Base.length(ic::GenomicIntervalCollection)
     return ic.length
 end
 
-function Base.eltype(::Type{IntervalCollection{I}}) where I
+function Base.eltype(::Type{GenomicIntervalCollection{I}}) where I
     return I
 end
 
-function Base.:(==)(a::IntervalCollection, b::IntervalCollection)
+function Base.:(==)(a::GenomicIntervalCollection, b::GenomicIntervalCollection)
+
     if length(a) != length(b)
         return false
     end
@@ -179,48 +180,48 @@ end
 # ---------
 
 #=
-mutable struct IntervalCollectionIteratorState{T}
+mutable struct GenomicIntervalCollectionIteratorState{T}
     i::Int # index into ordered_trees
     tree_state::ICTreeIteratorState{T}
 
-    function IntervalCollectionIteratorState{T}(i::Int) where T
+    function GenomicIntervalCollectionIteratorState{T}(i::Int) where T
         return new{T}(i)
     end
 
-    function IntervalCollectionIteratorState{T}(i::Int, tree_state) where T
+    function GenomicIntervalCollectionIteratorState{T}(i::Int, tree_state) where T
         return new{T}(i, tree_state)
     end
 end
 
-function iterinitstate(ic::IntervalCollection{T}) where T
+function iterinitstate(ic::GenomicIntervalCollection{T}) where T
     update_ordered_trees!(ic)
     i = 1
     while i <= length(ic.ordered_trees)
         tree_state = IntervalTrees.iterinitstate(ic.ordered_trees[i])
         if !(tree_state.leaf === nothing || isempty(tree_state.leaf))
-            return IntervalCollectionIteratorState{T}(i, tree_state)
+            return GenomicIntervalCollectionIteratorState{T}(i, tree_state)
         end
         i += 1
     end
-    return IntervalCollectionIteratorState{T}(i)
+    return GenomicIntervalCollectionIteratorState{T}(i)
 end
 
-function Base.start(ic::IntervalCollection{T}) where T
+function Base.start(ic::GenomicIntervalCollection{T}) where T
     update_ordered_trees!(ic)
     i = 1
     while i <= length(ic.ordered_trees)
         tree_state = start(ic.ordered_trees[i])
         if !done(ic.ordered_trees[i], tree_state)
-            return IntervalCollectionIteratorState{T}(i, tree_state)
+            return GenomicIntervalCollectionIteratorState{T}(i, tree_state)
         end
         i += 1
     end
-    return IntervalCollectionIteratorState{T}(i)
+    return GenomicIntervalCollectionIteratorState{T}(i)
 end
 =#
 
 #=
-function Base.iterate(ic::IntervalCollection, state=iterinitstate(ic))
+function Base.iterate(ic::GenomicIntervalCollection, state=iterinitstate(ic))
     i = state.i
     treeit = iterate(ic.ordered_trees[i], state.tree_state)
     if treeit === nothing
@@ -238,7 +239,7 @@ function Base.iterate(ic::IntervalCollection, state=iterinitstate(ic))
 end
 =#
 
-function iterprep(ic::IntervalCollection)
+function iterprep(ic::GenomicIntervalCollection)
     update_ordered_trees!(ic)
     return ()
 end
@@ -247,7 +248,7 @@ end
 # (ot iteration state, current ot element, current ot element state)
 # "ot" is shorthand for "ordered_trees"
 # This iterate method basically works like the Iterators.Flatten iterator.
-@propagate_inbounds function Base.iterate(ic::IntervalCollection, state = iterprep(ic))
+@propagate_inbounds function Base.iterate(ic::GenomicIntervalCollection, state = iterprep(ic))
     if state !== ()
         # Iterate over each interval in current ordered tree.
         tree_it = iterate(Base.tail(state)...)
@@ -260,7 +261,7 @@ end
 end
 
 #=
-function Base.next(ic::IntervalCollection, state)
+function Base.next(ic::GenomicIntervalCollection, state)
     i = state.i
     value, tree_state = next(ic.ordered_trees[i], state.tree_state)
     if done(ic.ordered_trees[i], tree_state)
@@ -277,7 +278,7 @@ function Base.next(ic::IntervalCollection, state)
     return value, state
 end
 
-function Base.done(ic::IntervalCollection, state)
+function Base.done(ic::GenomicIntervalCollection, state)
     return state.i > length(ic.ordered_trees)
 end
 =#
@@ -297,7 +298,7 @@ Find a the first interval with matching start and end points.
 
 Returns that interval, or 'nothing' if no interval was found.
 """
-function Base.findfirst(a::IntervalCollection, b::Interval; filter=true_cmp)
+function Base.findfirst(a::GenomicIntervalCollection, b::GenomicInterval; filter=true_cmp)
     if !haskey(a.trees, seqname(b))
         return nothing
     end
@@ -309,7 +310,7 @@ end
 # Overlaps
 # --------
 
-function eachoverlap(a::IntervalCollection{I}, query::Interval; filter::F = true_cmp) where {F,I}
+function eachoverlap(a::GenomicIntervalCollection{I}, query::GenomicInterval; filter::F = true_cmp) where {F,I}
     if haskey(a.trees, seqname(query))
         return ICTreeIntervalIntersectionIterator{F,I}(filter, ICTreeIntersection{I}(), a.trees[seqname(query)], query)
     end
@@ -317,11 +318,11 @@ function eachoverlap(a::IntervalCollection{I}, query::Interval; filter::F = true
     return ICTreeIntervalIntersectionIterator{F,I}(filter, ICTreeIntersection{I}(), ICTree{I}(), query)
 end
 
-function eachoverlap(query::Interval, b::IntervalCollection{T}; filter::F = true_cmp) where {F,T}
+function eachoverlap(query::GenomicInterval, b::GenomicIntervalCollection{I}; filter::F = true_cmp) where {F,I}
     return eachoverlap(b, query; filter = filter)
 end
 
-function eachoverlap(a::IntervalCollection, b::IntervalCollection; filter = true_cmp)
+function eachoverlap(a::GenomicIntervalCollection, b::GenomicIntervalCollection; filter = true_cmp)
     seqnames = collect(AbstractString, keys(a.trees) ∩ keys(b.trees))
     sort!(seqnames, lt = isless)
     a_trees = [a.trees[seqname] for seqname in seqnames]
@@ -414,42 +415,42 @@ function Base.done(it::IntersectIterator{F, S, T}, state) where {F, S, T}
 end
 =#
 
-function eachoverlap(a, b::IntervalCollection; filter=true_cmp)
-    return IntervalCollectionStreamIterator(filter, a, b)
+function eachoverlap(a, b::GenomicIntervalCollection; filter=true_cmp)
+    return GenomicIntervalCollectionStreamIterator(filter, a, b)
 end
 
-struct IntervalCollectionStreamIterator{F,S,Ib}
+struct GenomicIntervalCollectionStreamIterator{F,S,Ib}
     filter::F
     stream::S
-    collection::IntervalCollection{Ib}
+    collection::GenomicIntervalCollection{Ib}
 end
 
-function Base.eltype(::Type{IntervalCollectionStreamIterator{F,S,Ib}}) where {F,S,Ib}
+function Base.eltype(::Type{GenomicIntervalCollectionStreamIterator{F,S,Ib}}) where {F,S,Ib}
     return Tuple{intervaltype(eltype(S)),Ib}
 end
 
-function Base.IteratorSize(::Type{IntervalCollectionStreamIterator{F,S,Ib}}) where {F,S,Ib}
+function Base.IteratorSize(::Type{GenomicIntervalCollectionStreamIterator{F,S,Ib}}) where {F,S,Ib}
     return Base.SizeUnknown()
 end
 
 #= ### The old iteration protocol prior to version 0.7 / 1.0 of julia.
 
-mutable struct IntervalCollectionStreamIteratorState{F,Ta,Tb,U}
+mutable struct GenomicIntervalCollectionStreamIteratorState{F,Ta,Tb,U}
     intersection::ICTreeIntersection{Tb}
-    stream_value::Interval{Ta}
+    stream_value::GenomicInterval{Ta}
     stream_state::U
 
-    function IntervalCollectionStreamIteratorState{F,Ta,Tb,U}(intersection, stream_value, stream_state) where {F,Ta,Tb,U}
+    function GenomicIntervalCollectionStreamIteratorState{F,Ta,Tb,U}(intersection, stream_value, stream_state) where {F,Ta,Tb,U}
         return new{F,Ta,Tb,U}(intersection, stream_value, stream_state)
     end
 
-    function IntervalCollectionStreamIteratorState{F,Ta,Tb,U}() where {F,Ta,Tb,U}
+    function GenomicIntervalCollectionStreamIteratorState{F,Ta,Tb,U}() where {F,Ta,Tb,U}
         return new{F,Ta,Tb,U}(ICTreeIntersection{Tb}())
     end
 end
 
 # This mostly follows from SuccessiveTreeIntersectionIterator in IntervalTrees
-function Base.start(it::IntervalCollectionStreamIterator{F,S,T}) where {F,S,T}
+function Base.start(it::GenomicIntervalCollectionStreamIterator{F,S,T}) where {F,S,T}
     stream_state = start(it.stream)
     intersection = ICTreeIntersection{T}()
     while !done(it.stream, stream_state)
@@ -458,14 +459,14 @@ function Base.start(it::IntervalCollectionStreamIterator{F,S,T}) where {F,S,T}
             tree = it.collection.trees[seqname(stream_value)]
             IntervalTrees.firstintersection!(tree, stream_value, nothing, intersection, it.filter)
             if intersection.index != 0
-                return IntervalCollectionStreamIteratorState{F,T,metadatatype(it.stream),typeof(stream_state)}(intersection, stream_value, stream_state)
+                return GenomicIntervalCollectionStreamIteratorState{F,T,metadatatype(it.stream),typeof(stream_state)}(intersection, stream_value, stream_state)
             end
         end
     end
-    return IntervalCollectionStreamIteratorState{S,metadatatype(it.stream),typeof(stream_state)}()
+    return GenomicIntervalCollectionStreamIteratorState{S,metadatatype(it.stream),typeof(stream_state)}()
 end
 
-function Base.next(it::IntervalCollectionStreamIterator{F,S,T}, state) where {F,S,T}
+function Base.next(it::GenomicIntervalCollectionStreamIterator{F,S,T}, state) where {F,S,T}
     intersection = state.intersection
     entry = intersection.node.entries[intersection.index]
     return_value = (state.stream_value, entry)
@@ -480,7 +481,7 @@ function Base.next(it::IntervalCollectionStreamIterator{F,S,T}, state) where {F,
     return return_value, state
 end
 
-function Base.done(it::IntervalCollectionStreamIterator, state)
+function Base.done(it::GenomicIntervalCollectionStreamIterator, state)
     return state.intersection.index == 0
 end
 =#
@@ -488,7 +489,7 @@ end
 # New julia 0.7 / 1.0 iteration protocol for collection stream iterator.
 # State is a tuple:
 # (current_query, stream_state, intersection_object)
-function Base.iterate(it::IntervalCollectionStreamIterator{F,S,Ib}, state = ()) where {F,S,Ib}
+function Base.iterate(it::GenomicIntervalCollectionStreamIterator{F,S,Ib}, state = ()) where {F,S,Ib}
     # If first iteration, make empty intersection, otherwise get it from the state.
     intersection = (state !== () ? state[3] : ICTreeIntersection{Ib}())
 
@@ -518,11 +519,11 @@ function Base.iterate(it::IntervalCollectionStreamIterator{F,S,Ib}, state = ()) 
 end
 
 """
-    hasintersection(interval::Interval, col::IntervalCollection)::Bool
+    hasintersection(interval::GenomicInterval, col::GenomicIntervalCollection)::Bool
 
 Query whether an `interval` has an intersection with `col`.
 """
-function hasintersection(interval::Interval, col::IntervalCollection)
+function hasintersection(interval::GenomicInterval, col::GenomicIntervalCollection)
 
 	# Return early if chromosome is not in the interval collection.
 	if !haskey(col.trees, seqname(interval))
@@ -542,6 +543,6 @@ function hasintersection(interval::Interval, col::IntervalCollection)
 
 end
 
-function hasintersection(col::IntervalCollection)
+function hasintersection(col::GenomicIntervalCollection)
 	return interval -> hasintersection(interval, col)
 end

--- a/src/intervalcollection.jl
+++ b/src/intervalcollection.jl
@@ -128,7 +128,7 @@ function update_ordered_trees!(ic::GenomicIntervalCollection{I}) where I
     end
 end
 
-function Base.push!(ic::GenomicIntervalCollection{I}, i::I) where {I<:AbstractGenomicInterval}
+function Base.push!(ic::GenomicIntervalCollection{I}, i::AbstractGenomicInterval) where {I<:AbstractGenomicInterval}
     tree = get!(ic.trees, seqname(i)) do
         # Setup empty tree for new seqname key.
         ic.ordered_trees_outdated = true

--- a/src/intervalcollection.jl
+++ b/src/intervalcollection.jl
@@ -33,32 +33,37 @@
 #
 
 # Aliases for types of IntervalTrees.jl (IC: Interval Collection).
-const ICTree{T}                               = IntervalTrees.IntervalBTree{Int64,Interval{T},64}
-const ICTreeIteratorState{T}                  = IntervalTrees.IntervalBTreeIteratorState{Int64,Interval{T},64}
-const ICTreeIntersection{T}                   = IntervalTrees.Intersection{Int64,Interval{T},64}
-const ICTreeIntersectionIterator{F,S,T}       = IntervalTrees.IntersectionIterator{F,Int64,Interval{S},64,Interval{T},64}
-const ICTreeIntervalIntersectionIterator{F,T} = IntervalTrees.IntervalIntersectionIterator{F, Int64,Interval{T},64}
+const ICTree{I}                               = IntervalTrees.IntervalBTree{Int64,I,64}
+const ICTreeIteratorState{I}                  = IntervalTrees.IntervalBTreeIteratorState{Int64,I,64}
+const ICTreeIntersection{I}                   = IntervalTrees.Intersection{Int64,I,64}
+const ICTreeIntersectionIterator{F,Ia,Ib}     = IntervalTrees.IntersectionIterator{F,Int64,Ia,64,Ib,64}
+const ICTreeIntervalIntersectionIterator{F,I} = IntervalTrees.IntervalIntersectionIterator{F,Int64,I,64}
 
 "An IntervalCollection is an efficiently stored and indexed set of annotated genomic intervals."
-mutable struct IntervalCollection{T}
+mutable struct IntervalCollection{I}
     # Sequence name mapped to IntervalTree, which in turn maps intervals to a list of metadata.
-    trees::Dict{String,ICTree{T}}
+    trees::Dict{String,ICTree{I}}
 
     # Keep track of the number of stored intervals.
     length::Int
 
     # A vector of values(trees) sorted on sequence name.
     # This is used to iterate intervals as efficiently as possible, but is only updated as needed, indicated by the ordered_trees_outdated flag.
-    ordered_trees::Vector{ICTree{T}}
+    ordered_trees::Vector{ICTree{I}}
     ordered_trees_outdated::Bool
 
-    "Empty initaialzation."
+    "Empty initialization."
     function IntervalCollection{T}() where T
-        return new{T}(Dict{String,ICTree{T}}(), 0, ICTree{T}[], false)
+        return IntervalCollection{Interval{T}}()
+    end
+
+    # Longhand constructor.
+    function IntervalCollection{I}() where {I<:Interval}
+        return new{I}(Dict{String,ICTree{I}}(), 0, ICTree{I}[], false)
     end
 
     "Bulk insertion."
-    function IntervalCollection{T}(intervals::AbstractVector{Interval{T}}, sort::Bool=false) where T
+    function IntervalCollection{I}(intervals::AbstractVector{I}, sort::Bool=false) where {I<:Interval}
         if sort
             sort!(intervals)
         else
@@ -68,34 +73,42 @@ mutable struct IntervalCollection{T}
         end
 
         n = length(intervals)
-        trees = Dict{String,ICTree{T}}()
+        trees = Dict{String,ICTree{I}}()
         i = 1
         while i <= n
             j = i
             while j <= n && seqname(intervals[i]) == seqname(intervals[j])
                 j += 1
             end
-            trees[seqname(intervals[i])] = ICTree{T}(view(intervals, i:j-1))
+            trees[seqname(intervals[i])] = ICTree{I}(view(intervals, i:j-1))
             i = j
         end
-        return new{T}(trees, n, ICTree{T}[], true)
+        return new{I}(trees, n, ICTree{I}[], true)
     end
 end
 
 """
-    IntervalCollection(intervals::AbstractVector{Interval{T}}, sort::Bool=false) where T
+    IntervalCollection(intervals::AbstractVector{I}, sort::Bool=false) where {I<:Interval}
 Shorthand constructor.
 """
-function IntervalCollection(intervals::AbstractVector{Interval{T}}, sort::Bool=false) where T
-    return IntervalCollection{T}(intervals, sort)
+function IntervalCollection(intervals::AbstractVector{I}, sort::Bool=false) where {I<:Interval}
+    return IntervalCollection{I}(intervals, sort)
 end
 
 """
-    IntervalCollection{T}(data, sort::Bool=false) where T
+    IntervalCollection{T}(data, sort::Bool=true) where {T}
+Shorthand for metadata type bulk insertion.
+"""
+function IntervalCollection{T}(data, sort::Bool=true) where {T}
+    return IntervalCollection{Interval{T}}(collect(Interval{T}, data), sort)
+end
+
+"""
+    IntervalCollection{I}(data, sort::Bool=false) where {I<:Interval}
 Constructor that offers conversion through collection.
 """
-function IntervalCollection{T}(data, sort::Bool=false) where T
-    return IntervalCollection(collect(Interval{T}, data), sort)
+function IntervalCollection{I}(data, sort::Bool=false) where {I<:Interval}
+    return IntervalCollection(collect(I, data), sort)
 end
 
 """
@@ -106,29 +119,29 @@ function IntervalCollection(data, sort::Bool=false)
     return IntervalCollection(collect(Interval{metadatatype(data)}, data), sort)
 end
 
-function update_ordered_trees!(ic::IntervalCollection{T}) where T
+function update_ordered_trees!(ic::IntervalCollection{I}) where I
     if ic.ordered_trees_outdated
-        ic.ordered_trees = collect(ICTree{T}, values(ic.trees))
+        ic.ordered_trees = collect(ICTree{I}, values(ic.trees))
         p = sortperm(collect(AbstractString, keys(ic.trees)), lt = isless)
         ic.ordered_trees = ic.ordered_trees[p]
         ic.ordered_trees_outdated = false
     end
 end
 
-function Base.push!(ic::IntervalCollection{T}, i::Interval{T}) where T
+function Base.push!(ic::IntervalCollection{I}, i::I) where {I<:Interval}
     tree = get!(ic.trees, seqname(i)) do
         # Setup empty tree for new seqname key.
         ic.ordered_trees_outdated = true
-        return ICTree{T}()
+        return ICTree{I}()
     end
     push!(tree, i)
     ic.length += 1
     return ic
 end
 
-function Base.show(io::IO, ic::IntervalCollection{T}) where T
+function Base.show(io::IO, ic::IntervalCollection{I}) where I
     n_entries = length(ic)
-    println(io, "IntervalCollection{$(T)} with $(n_entries) intervals:")
+    println(io, "IntervalCollection{$(I)} with $(n_entries) intervals:")
     if n_entries > 0
         for (k, i) in enumerate(ic)
             if k > 8
@@ -146,8 +159,8 @@ function Base.length(ic::IntervalCollection)
     return ic.length
 end
 
-function Base.eltype(::Type{IntervalCollection{T}}) where T
-    return Interval{T}
+function Base.eltype(::Type{IntervalCollection{I}}) where I
+    return I
 end
 
 function Base.:(==)(a::IntervalCollection, b::IntervalCollection)
@@ -296,12 +309,12 @@ end
 # Overlaps
 # --------
 
-function eachoverlap(a::IntervalCollection{T}, query::Interval; filter::F = true_cmp) where {F,T}
+function eachoverlap(a::IntervalCollection{I}, query::Interval; filter::F = true_cmp) where {F,I}
     if haskey(a.trees, seqname(query))
-        return ICTreeIntervalIntersectionIterator{F,T}(filter, ICTreeIntersection{T}(), a.trees[seqname(query)], query)
+        return ICTreeIntervalIntersectionIterator{F,I}(filter, ICTreeIntersection{I}(), a.trees[seqname(query)], query)
     end
 
-    return ICTreeIntervalIntersectionIterator{F,T}(filter, ICTreeIntersection{T}(), ICTree{T}(), query)
+    return ICTreeIntervalIntersectionIterator{F,I}(filter, ICTreeIntersection{I}(), ICTree{I}(), query)
 end
 
 function eachoverlap(query::Interval, b::IntervalCollection{T}; filter::F = true_cmp) where {F,T}
@@ -316,10 +329,10 @@ function eachoverlap(a::IntervalCollection, b::IntervalCollection; filter = true
     return IntersectIterator(filter, a_trees, b_trees)
 end
 
-struct IntersectIterator{F, S, T}
+struct IntersectIterator{F,Ia,Ib}
     filter::F
-    a_trees::Vector{ICTree{S}}
-    b_trees::Vector{ICTree{T}}
+    a_trees::Vector{ICTree{Ia}}
+    b_trees::Vector{ICTree{Ib}}
 end
 
 #=
@@ -337,11 +350,11 @@ mutable struct IntersectIteratorState{F,S,T}
 end
 =#
 
-function Base.eltype(::Type{IntersectIterator{F,S,T}}) where {F,S,T}
-    return Tuple{Interval{S},Interval{T}}
+function Base.eltype(::Type{IntersectIterator{F,Ia,Ib}}) where {F,Ia,Ib}
+    return Tuple{Ia,Ib}
 end
 
-function Base.IteratorSize(::Type{IntersectIterator{F,S,T}}) where {F,S,T}
+function Base.IteratorSize(::Type{IntersectIterator{F,Ia,Ib}}) where {F,Ia,Ib}
     return Base.SizeUnknown()
 end
 
@@ -362,7 +375,7 @@ end
 
 # State is a tuple:
 # (tree pair iteration state, current intersect iterator, current intersect iterator state)
-function Base.iterate(it::IntersectIterator{F, S, T}, state = ()) where {F,S,T}
+function Base.iterate(it::IntersectIterator{F,Ia,Ib}, state = ()) where {F,Ia,Ib}
     if state !== ()
         # Iterate over each intersection between two trees.
         isect = iterate(Base.tail(state)...)
@@ -405,17 +418,17 @@ function eachoverlap(a, b::IntervalCollection; filter=true_cmp)
     return IntervalCollectionStreamIterator(filter, a, b)
 end
 
-struct IntervalCollectionStreamIterator{F,S,T}
+struct IntervalCollectionStreamIterator{F,S,Ib}
     filter::F
     stream::S
-    collection::IntervalCollection{T}
+    collection::IntervalCollection{Ib}
 end
 
-function Base.eltype(::Type{IntervalCollectionStreamIterator{F,S,T}}) where {F,S,T}
-    return Tuple{Interval{metadatatype(S)},Interval{T}}
+function Base.eltype(::Type{IntervalCollectionStreamIterator{F,S,Ib}}) where {F,S,Ib}
+    return Tuple{Interval{metadatatype(S)},Ib}
 end
 
-function Base.IteratorSize(::Type{IntervalCollectionStreamIterator{F,S,T}}) where {F,S,T}
+function Base.IteratorSize(::Type{IntervalCollectionStreamIterator{F,S,Ib}}) where {F,S,Ib}
     return Base.SizeUnknown()
 end
 
@@ -475,9 +488,9 @@ end
 # New julia 0.7 / 1.0 iteration protocol for collection stream iterator.
 # State is a tuple:
 # (current_query, stream_state, intersection_object)
-function Base.iterate(it::IntervalCollectionStreamIterator{F,S,T}, state = ()) where {F,S,T}
+function Base.iterate(it::IntervalCollectionStreamIterator{F,S,Ib}, state = ()) where {F,S,Ib}
     # If first iteration, make empty intersection, otherwise get it from the state.
-    intersection = (state !== () ? state[3] : ICTreeIntersection{T}())
+    intersection = (state !== () ? state[3] : ICTreeIntersection{Ib}())
 
     # If this is not the first iteration, and there is an available intersection for the current query, return it and search for the next intersection.
     if state !== () && intersection.index != 0

--- a/src/intervalcollection.jl
+++ b/src/intervalcollection.jl
@@ -58,12 +58,12 @@ mutable struct GenomicIntervalCollection{I}
     end
 
     # Longhand constructor.
-    function GenomicIntervalCollection{I}() where {I<:GenomicInterval}
+    function GenomicIntervalCollection{I}() where {I<:AbstractGenomicInterval}
         return new{I}(Dict{String,ICTree{I}}(), 0, ICTree{I}[], false)
     end
 
     "Bulk insertion."
-    function GenomicIntervalCollection{I}(intervals::AbstractVector{I}, sort::Bool=false) where {I<:GenomicInterval}
+    function GenomicIntervalCollection{I}(intervals::AbstractVector{I}, sort::Bool=false) where {I<:AbstractGenomicInterval}
         if sort
             sort!(intervals)
         else
@@ -91,7 +91,7 @@ end
     GenomicIntervalCollection(intervals::AbstractVector{I}, sort::Bool=false) where {I<:Interval}
 Shorthand constructor.
 """
-function GenomicIntervalCollection(intervals::AbstractVector{I}, sort::Bool=false) where {I<:GenomicInterval}
+function GenomicIntervalCollection(intervals::AbstractVector{I}, sort::Bool=false) where {I<:AbstractGenomicInterval}
     return GenomicIntervalCollection{I}(intervals, sort)
 end
 
@@ -107,7 +107,7 @@ end
     GenomicIntervalCollection{I}(data, sort::Bool=false) where {I<:Interval}
 Constructor that offers conversion through collection.
 """
-function GenomicIntervalCollection{I}(data, sort::Bool=false) where {I<:GenomicInterval}
+function GenomicIntervalCollection{I}(data, sort::Bool=false) where {I<:AbstractGenomicInterval}
     return GenomicIntervalCollection(collect(I, data), sort)
 end
 
@@ -128,7 +128,7 @@ function update_ordered_trees!(ic::GenomicIntervalCollection{I}) where I
     end
 end
 
-function Base.push!(ic::GenomicIntervalCollection{I}, i::I) where {I<:GenomicInterval}
+function Base.push!(ic::GenomicIntervalCollection{I}, i::I) where {I<:AbstractGenomicInterval}
     tree = get!(ic.trees, seqname(i)) do
         # Setup empty tree for new seqname key.
         ic.ordered_trees_outdated = true
@@ -298,7 +298,7 @@ Find a the first interval with matching start and end points.
 
 Returns that interval, or 'nothing' if no interval was found.
 """
-function Base.findfirst(a::GenomicIntervalCollection, b::GenomicInterval; filter=true_cmp)
+function Base.findfirst(a::GenomicIntervalCollection, b::AbstractGenomicInterval; filter=true_cmp)
     if !haskey(a.trees, seqname(b))
         return nothing
     end
@@ -310,7 +310,7 @@ end
 # Overlaps
 # --------
 
-function eachoverlap(a::GenomicIntervalCollection{I}, query::GenomicInterval; filter::F = true_cmp) where {F,I}
+function eachoverlap(a::GenomicIntervalCollection{I}, query::AbstractGenomicInterval; filter::F = true_cmp) where {F,I}
     if haskey(a.trees, seqname(query))
         return ICTreeIntervalIntersectionIterator{F,I}(filter, ICTreeIntersection{I}(), a.trees[seqname(query)], query)
     end
@@ -318,7 +318,7 @@ function eachoverlap(a::GenomicIntervalCollection{I}, query::GenomicInterval; fi
     return ICTreeIntervalIntersectionIterator{F,I}(filter, ICTreeIntersection{I}(), ICTree{I}(), query)
 end
 
-function eachoverlap(query::GenomicInterval, b::GenomicIntervalCollection{I}; filter::F = true_cmp) where {F,I}
+function eachoverlap(query::AbstractGenomicInterval, b::GenomicIntervalCollection{I}; filter::F = true_cmp) where {F,I}
     return eachoverlap(b, query; filter = filter)
 end
 
@@ -519,11 +519,11 @@ function Base.iterate(it::GenomicIntervalCollectionStreamIterator{F,S,Ib}, state
 end
 
 """
-    hasintersection(interval::GenomicInterval, col::GenomicIntervalCollection)::Bool
+    hasintersection(interval::AbstractGenomicInterval, col::GenomicIntervalCollection)::Bool
 
 Query whether an `interval` has an intersection with `col`.
 """
-function hasintersection(interval::GenomicInterval, col::GenomicIntervalCollection)
+function hasintersection(interval::AbstractGenomicInterval, col::GenomicIntervalCollection)
 
 	# Return early if chromosome is not in the interval collection.
 	if !haskey(col.trees, seqname(interval))

--- a/src/intervalcollection.jl
+++ b/src/intervalcollection.jl
@@ -40,7 +40,7 @@ const ICTreeIntersectionIterator{F,Ia,Ib}     = IntervalTrees.IntersectionIterat
 const ICTreeIntervalIntersectionIterator{F,I} = IntervalTrees.IntervalIntersectionIterator{F,Int64,I,64}
 
 "A GenomicIntervalCollection is an efficiently stored and indexed set of annotated genomic intervals."
-mutable struct GenomicIntervalCollection{I}
+mutable struct GenomicIntervalCollection{I} <: AbstractGenomicCollection{I}
     # Sequence name mapped to IntervalTree, which in turn maps intervals to a list of metadata.
     trees::Dict{String,ICTree{I}}
 

--- a/src/overlap.jl
+++ b/src/overlap.jl
@@ -22,7 +22,7 @@ end
 Create an iterator of overlapping intervals between `intervals_a` and `intervals_b`.
 
 This function assumes elements of `intervals_a` and `intervals_b` are sorted by its sequence name and left position.
-If the element type is not a subtype of `GenomicFeatures.GenomicInterval`, elements are converted to `GenomicInterval` objects.
+If the element type is not a subtype of `GenomicFeatures.AbstractGenomicInterval`, elements are converted to `GenomicInterval` objects.
 
 The third optional argument is a function that defines the order of sequence names.
 The default function is `Base.isless`, which is the lexicographical order.
@@ -146,7 +146,7 @@ end
 #   -1 when `i1` precedes `i2`,
 #   0 when `i1` overlaps with `i2`, and
 #   +1 when `i1` follows `i2`.
-function compare_overlap(i1::GenomicInterval, i2::GenomicInterval, isless::Function)
+function compare_overlap(i1::AbstractGenomicInterval, i2::AbstractGenomicInterval, isless::Function)
     if isless(seqname(i1), seqname(i2))
         return -1
     end
@@ -168,7 +168,7 @@ function compare_overlap(i1::GenomicInterval, i2::GenomicInterval, isless::Funct
 end
 
 # Faster comparison for `Base.isless`.  Note that `Base.isless` must be consistent wtih `Base.cmp` to work correctly.
-function compare_overlap(i1::GenomicInterval, i2::GenomicInterval, ::typeof(Base.isless))
+function compare_overlap(i1::AbstractGenomicInterval, i2::AbstractGenomicInterval, ::typeof(Base.isless))
     c = cmp(seqname(i1), seqname(i2))
 
     if c != 0

--- a/src/overlap.jl
+++ b/src/overlap.jl
@@ -2,8 +2,8 @@
 # ================
 
 struct OverlapIterator{Sa,Sb,L,F}
-    intervals_a::Sa
-    intervals_b::Sb
+    interval_stream_a::Sa
+    interval_stream_b::Sb
     isless::L
     filter::F
 end
@@ -49,11 +49,12 @@ end
 
 
 function Base.iterate(iter::OverlapIterator)
-    next_a = iterate(iter.intervals_a)
-    next_b = iterate(iter.intervals_b)
+    next_a = iterate(iter.interval_stream_a)
+    next_b = iterate(iter.interval_stream_b)
 
-    Ta = metadatatype(iter.intervals_a)
-    Tb = metadatatype(iter.intervals_b)
+    Ta = metadatatype(iter.interval_stream_a)
+    Tb = metadatatype(iter.interval_stream_b)
+
     state = OverlapIteratorState(Ta, Tb, next_a, next_b)
 
     return iterate(iter, state)
@@ -86,7 +87,7 @@ function Base.iterate(iter::OverlapIterator, state::OverlapIteratorState{Sa,Sb,T
         if queue_index > lastindex(state.queue)
             # end of queue: add more to queue, or advance a
             if next_b === nothing
-                next_a = iterate(iter.intervals_a, state_a)
+                next_a = iterate(iter.interval_stream_a, state_a)
                 if next_a === nothing
                     return break
                 end
@@ -103,7 +104,7 @@ function Base.iterate(iter::OverlapIterator, state::OverlapIteratorState{Sa,Sb,T
                     check_ordered(queue[end], interval_b, iter.isless)
                 end
                 push!(queue, interval_b)
-                next_b = iterate(iter.intervals_b, state_b)
+                next_b = iterate(iter.interval_stream_b, state_b)
             end
         else
             entry_a, state_a = next_a
@@ -114,7 +115,7 @@ function Base.iterate(iter::OverlapIterator, state::OverlapIteratorState{Sa,Sb,T
 
             if c < 0
                 # No more possible intersections with interval_a, advance
-                next_a = iterate(iter.intervals_a, state_a)
+                next_a = iterate(iter.interval_stream_a, state_a)
                 if next_a === nothing
                     break
                 end

--- a/src/overlap.jl
+++ b/src/overlap.jl
@@ -22,7 +22,7 @@ end
 Create an iterator of overlapping intervals between `intervals_a` and `intervals_b`.
 
 This function assumes elements of `intervals_a` and `intervals_b` are sorted by its sequence name and left position.
-If the element type is not a subtype of `GenomicFeatures.Interval`, elements are converted to `Interval` objects.
+If the element type is not a subtype of `GenomicFeatures.GenomicInterval`, elements are converted to `GenomicInterval` objects.
 
 The third optional argument is a function that defines the order of sequence names.
 The default function is `Base.isless`, which is the lexicographical order.
@@ -146,7 +146,7 @@ end
 #   -1 when `i1` precedes `i2`,
 #   0 when `i1` overlaps with `i2`, and
 #   +1 when `i1` follows `i2`.
-function compare_overlap(i1::Interval, i2::Interval, isless::Function)
+function compare_overlap(i1::GenomicInterval, i2::GenomicInterval, isless::Function)
     if isless(seqname(i1), seqname(i2))
         return -1
     end
@@ -168,7 +168,7 @@ function compare_overlap(i1::Interval, i2::Interval, isless::Function)
 end
 
 # Faster comparison for `Base.isless`.  Note that `Base.isless` must be consistent wtih `Base.cmp` to work correctly.
-function compare_overlap(i1::Interval, i2::Interval, ::typeof(Base.isless))
+function compare_overlap(i1::GenomicInterval, i2::GenomicInterval, ::typeof(Base.isless))
     c = cmp(seqname(i1), seqname(i2))
 
     if c != 0

--- a/src/overlap.jl
+++ b/src/overlap.jl
@@ -17,18 +17,18 @@ function Base.IteratorSize(::Type{OverlapIterator{Sa,Sb,L,F}}) where {Sa,Sb,L,F}
 end
 
 """
-    eachoverlap(intervals_a, intervals_b, [seqname_isless=Base.isless])
+    eachoverlap(intervals_a, intervals_b, [groupname_isless=Base.isless])
 
 Create an iterator of overlapping intervals between `intervals_a` and `intervals_b`.
 
-This function assumes elements of `intervals_a` and `intervals_b` are sorted by its sequence name and left position.
+This function assumes elements of `intervals_a` and `intervals_b` are sorted by its group name and left position.
 If the element type is not a subtype of `GenomicFeatures.AbstractGenomicInterval`, elements are converted to `GenomicInterval` objects.
 
-The third optional argument is a function that defines the order of sequence names.
+The third optional argument is a function that defines the order of the group names.
 The default function is `Base.isless`, which is the lexicographical order.
 """
-function eachoverlap(intervals_a, intervals_b, seqname_isless=Base.isless; filter=true_cmp)
-    return OverlapIterator(intervals_a, intervals_b, seqname_isless, filter)
+function eachoverlap(intervals_a, intervals_b, groupname_isless=Base.isless; filter=true_cmp)
+    return OverlapIterator(intervals_a, intervals_b, groupname_isless, filter)
 end
 
 struct OverlapIteratorState{Na,Nb,Ia,Ib}
@@ -146,15 +146,15 @@ end
 #   0 when `i1` overlaps with `i2`, and
 #   +1 when `i1` follows `i2`.
 function compare_overlap(i1::AbstractGenomicInterval, i2::AbstractGenomicInterval, isless::Function)
-    if isless(seqname(i1), seqname(i2))
+    if isless(groupname(i1), groupname(i2))
         return -1
     end
 
-    if isless(seqname(i2), seqname(i1))
+    if isless(groupname(i2), groupname(i1))
         return +1
     end
 
-    # seqname(i1) == seqname(i2)
+    # groupname(i1) == groupname(i2)
     if rightposition(i1) < leftposition(i2)
         return -1
     end
@@ -168,7 +168,7 @@ end
 
 # Faster comparison for `Base.isless`.  Note that `Base.isless` must be consistent wtih `Base.cmp` to work correctly.
 function compare_overlap(i1::AbstractGenomicInterval, i2::AbstractGenomicInterval, ::typeof(Base.isless))
-    c = cmp(seqname(i1), seqname(i2))
+    c = cmp(groupname(i1), groupname(i2))
 
     if c != 0
         return c

--- a/src/overlap.jl
+++ b/src/overlap.jl
@@ -69,16 +69,15 @@ function check_ordered(i1, i2, compare_func)
     return nothing
 end
 
+function Base.iterate(iter::OverlapIterator, state::OverlapIteratorState{Nothing,Nb,Ia,Ib}) where {Nb,Ia,Ib}
+    return nothing
+end
 
 function Base.iterate(iter::OverlapIterator, state::OverlapIteratorState{Na,Nb,Ia,Ib}) where {Na,Nb,Ia,Ib}
     next_a      = state.next_a
     next_b      = state.next_b
     queue       = state.queue
     queue_index = state.queue_index
-
-    if next_a === nothing
-        return nothing
-    end
 
     entry_a, state_a = next_a
     interval_a = convert(Ia, entry_a)

--- a/src/position.jl
+++ b/src/position.jl
@@ -2,18 +2,18 @@ abstract type AbstractGenomicPosition{T} <: GenomicFeatures.AbstractGenomicInter
 
 "A genomic position is distinguished from an interval and only specifies a position with some associated metadata."
 mutable struct GenomicPosition{T} <: AbstractGenomicPosition{T}
-    seqname::String
+    groupname::String
     pos::Int64
     metadata::T
 end
 
-function GenomicPosition(seqname::String, pos::Integer, metadata::T = nothing) where T
-    return GenomicPosition{T}(seqname, pos, metadata)
+function GenomicPosition(groupname::String, pos::Integer, metadata::T = nothing) where T
+    return GenomicPosition{T}(groupname, pos, metadata)
 end
 
-function GenomicPosition(seqname::String, range::UnitRange{<:Integer}, metadata::T = nothing) where T
+function GenomicPosition(groupname::String, range::UnitRange{<:Integer}, metadata::T = nothing) where T
     length(range) == 1 || error("Position must have a length of 1.")
-    return GenomicPosition(seqname, first(range), metadata)
+    return GenomicPosition(groupname, first(range), metadata)
 end
 
 function BioGenerics.leftposition(site::AbstractGenomicPosition)
@@ -35,27 +35,27 @@ end
 
 function Base.show(io::IO, p::AbstractGenomicPosition)
     if get(io, :compact, false)
-        print(io, seqname(p), ":", position(p))
+        print(io, groupname(p), ":", position(p))
     else
         println(io, summary(p), ':')
-        println(io, "  sequence name: ", seqname(p))
+        println(io, "  group name: ", groupname(p))
           print(io, "  position: ", position(p))
     end
 end
 
 function Base.show(io::IO, p::GenomicPosition)
     if get(io, :compact, false)
-        print(io, seqname(p), ":", position(p), "  ", metadata(p) === nothing ? "nothing" : metadata(p))
+        print(io, groupname(p), ":", position(p), "  ", metadata(p) === nothing ? "nothing" : metadata(p))
     else
         println(io, summary(p), ':')
-        println(io, "  sequence name: ", seqname(p))
+        println(io, "  group name: ", groupname(p))
         println(io, "  position: ", position(p))
           print(io, "  metadata: ", metadata(p) === nothing ? "nothing" : metadata(p))
     end
 end
 
 function Base.:(==)(a::GenomicPosition, b::GenomicPosition) where T
-    return seqname(a)  == seqname(b) &&
-           position(a) == position(b) &&
-           metadata(a) == metadata(b)
+    return groupname(a) == groupname(b) &&
+           position(a)  == position(b) &&
+           metadata(a)  == metadata(b)
 end

--- a/src/position.jl
+++ b/src/position.jl
@@ -1,0 +1,61 @@
+abstract type AbstractGenomicPosition{T} <: GenomicFeatures.AbstractGenomicInterval{T} end
+
+"A genomic position is distinguished from an interval and only specifies a position with some associated metadata."
+mutable struct GenomicPosition{T} <: AbstractGenomicPosition{T}
+    seqname::String
+    pos::Int64
+    metadata::T
+end
+
+function GenomicPosition(seqname::String, pos::Integer, metadata::T = nothing) where T
+    return GenomicPosition{T}(seqname, pos, metadata)
+end
+
+function GenomicPosition(seqname::String, range::UnitRange{<:Integer}, metadata::T = nothing) where T
+    length(range) == 1 || error("Position must have a length of 1.")
+    return GenomicPosition(seqname, first(range), metadata)
+end
+
+function BioGenerics.leftposition(site::AbstractGenomicPosition)
+    return site.pos
+end
+
+function BioGenerics.rightposition(site::AbstractGenomicPosition)
+    return site.pos
+end
+
+"""
+    position(p::AbstractGenomicPosition)
+
+Return the position of `p`.
+"""
+function Base.position(site::AbstractGenomicPosition)
+    return leftposition(site)
+end
+
+function Base.show(io::IO, p::AbstractGenomicPosition)
+    if get(io, :compact, false)
+        print(io, seqname(p), ":", position(p))
+    else
+        println(io, summary(p), ':')
+        println(io, "  sequence name: ", seqname(p))
+          print(io, "  position: ", position(p))
+    end
+end
+
+function Base.show(io::IO, p::GenomicPosition)
+    if get(io, :compact, false)
+        print(io, seqname(p), ":", position(p), "  ", metadata(p) === nothing ? "nothing" : metadata(p))
+    else
+        println(io, summary(p), ':')
+        println(io, "  sequence name: ", seqname(p))
+        println(io, "  position: ", position(p))
+          print(io, "  metadata: ", metadata(p) === nothing ? "nothing" : metadata(p))
+    end
+end
+
+function Base.:(==)(a::GenomicPosition, b::GenomicPosition) where T
+    return seqname(a)  == seqname(b) &&
+           position(a) == position(b) &&
+           metadata(a) == metadata(b)
+end

--- a/test/Utilities.jl
+++ b/test/Utilities.jl
@@ -4,10 +4,10 @@ using Distributions
 using GenomicFeatures
 using Random
 
-# Generate an array of n random GenomicInterval{Int} object. With sequence names
-# samples from seqnames, and intervals drawn to lie in [1, maxpos].
-function random_intervals(seqnames::Vector{String}, maxpos::Int, n::Int)
-    seq_dist = Categorical(length(seqnames))
+# Generate an array of n random GenomicInterval{Int} object.
+# With group name samples from groupnames, and intervals drawn to lie in [1, maxpos].
+function random_intervals(groupnames::Vector{String}, maxpos::Int, n::Int)
+    seq_dist = Categorical(length(groupnames))
     strand_dist = Categorical(2)
     length_dist = Normal(1000, 1000)
     intervals = Vector{GenomicInterval{Int}}(undef, n)
@@ -19,14 +19,14 @@ function random_intervals(seqnames::Vector{String}, maxpos::Int, n::Int)
         first = rand(1:maxpos-intlen)
         last = first + intlen - 1
         strand = rand(strand_dist) == 1 ? STRAND_POS : STRAND_NEG
-        intervals[i] = GenomicInterval{Int}(seqnames[rand(seq_dist)], first, last, strand, i)
+        intervals[i] = GenomicInterval{Int}(groupnames[rand(seq_dist)], first, last, strand, i)
     end
     return intervals
 end
 
-function random_intervals(seqnames::Vector{String}, maxpos::Int, n::Int, seed::Int)
+function random_intervals(groupnames::Vector{String}, maxpos::Int, n::Int, seed::Int)
     Random.seed!(seed)
-    return random_intervals(seqnames, maxpos, n)
+    return random_intervals(groupnames, maxpos, n)
 end
 
 end  # module Utilities

--- a/test/Utilities.jl
+++ b/test/Utilities.jl
@@ -4,13 +4,13 @@ using Distributions
 using GenomicFeatures
 using Random
 
-# Generate an array of n random Interval{Int} object. With sequence names
+# Generate an array of n random GenomicInterval{Int} object. With sequence names
 # samples from seqnames, and intervals drawn to lie in [1, maxpos].
 function random_intervals(seqnames::Vector{String}, maxpos::Int, n::Int)
     seq_dist = Categorical(length(seqnames))
     strand_dist = Categorical(2)
     length_dist = Normal(1000, 1000)
-    intervals = Vector{Interval{Int}}(undef, n)
+    intervals = Vector{GenomicInterval{Int}}(undef, n)
     for i in 1:n
         intlen = maxpos
         while intlen >= maxpos || intlen <= 0
@@ -19,7 +19,7 @@ function random_intervals(seqnames::Vector{String}, maxpos::Int, n::Int)
         first = rand(1:maxpos-intlen)
         last = first + intlen - 1
         strand = rand(strand_dist) == 1 ? STRAND_POS : STRAND_NEG
-        intervals[i] = Interval{Int}(seqnames[rand(seq_dist)], first, last, strand, i)
+        intervals[i] = GenomicInterval{Int}(seqnames[rand(seq_dist)], first, last, strand, i)
     end
     return intervals
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,6 +209,16 @@ end
         @test GenomicFeatures.baseintervaltype(interval) === GenomicInterval
     end
 
+    @testset "metadatatype" begin
+        interval = GenomicInterval("test", 1, 2)
+        @test typeof(interval) == GenomicInterval{Nothing}
+        @test GenomicFeatures.metadatatype(interval) === Nothing
+
+        interval = GenomicInterval("test", 1, 2, '.', 3.0)
+        @test typeof(interval) == GenomicInterval{Float64}
+        @test GenomicFeatures.metadatatype(interval) === Float64
+    end
+
     @testset "precedes" begin
         interval_a = GenomicInterval("test", 1, 2)
         interval_b = GenomicInterval("test", 2, 3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using GenomicFeatures
 using Test
-using Documenter
 
 import Random
 
@@ -560,9 +559,5 @@ end
     @test String(take!(buf)) == "WithoutMetadatata:\n  group name: chr1\n  leftmost position: 1\n  rightmost position: 2\n  metadata: nothing"
 
 end #testset "Custom Concrete Types"
-
-# Include doctests.
-DocMeta.setdocmeta!(GenomicFeatures, :DocTestSetup, :(using GenomicFeatures); recursive=true)
-doctest(GenomicFeatures; manual = false)
 
 end #testset GenomicFeatures

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,6 +201,7 @@ end
 end
 
 @testset "IntervalCollection" begin
+
     @testset "Insertion/Iteration" begin
         n = 100000
         intervals = random_intervals(["one", "two", "three"], 1000000, n)
@@ -213,6 +214,14 @@ end
             push!(ic, interval)
         end
         @test is_all_ordered(collect(Interval{Int}, ic))
+    end
+
+    @testset "Bulk Insertion" begin
+        i = Interval("chr1", 10, 20, '+', 1)
+
+        # Test equivalency of shorthand and longhand types.
+        @test IntervalCollection([i]) == IntervalCollection{Int}([i]) == IntervalCollection{Interval{Int}}([i])
+
     end
 
     @testset "Intersection" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,9 +28,9 @@ function simple_intersection(intervals_a, intervals_b; filter=(a,b)->true)
     while i <= length(intervals_a) && j <= length(intervals_b)
         ai = intervals_a[i]
         bj = intervals_b[j]
-        if isless(seqname(ai), seqname(bj)) || (seqname(ai) == seqname(bj) && rightposition(ai) < leftposition(bj))
+        if isless(groupname(ai), groupname(bj)) || (groupname(ai) == groupname(bj) && rightposition(ai) < leftposition(bj))
             i += 1
-        elseif isless(seqname(bj), seqname(ai)) || (seqname(ai) == seqname(bj) && rightposition(bj) < leftposition(ai))
+        elseif isless(groupname(bj), groupname(ai)) || (groupname(ai) == groupname(bj) && rightposition(bj) < leftposition(ai))
             j += 1
         else
             k = j
@@ -49,25 +49,25 @@ end
 function simple_coverage(intervals)
     seqlens = Dict{String, Int}()
     for interval in intervals
-        if get(seqlens, seqname(interval), -1) < rightposition(interval)
-            seqlens[seqname(interval)] = rightposition(interval)
+        if get(seqlens, groupname(interval), -1) < rightposition(interval)
+            seqlens[groupname(interval)] = rightposition(interval)
         end
     end
 
     covarrays = Dict{String, Vector{Int}}()
-    for (seqname, seqlen) in seqlens
-        covarrays[seqname] = zeros(Int, seqlen)
+    for (groupname, seqlen) in seqlens
+        covarrays[groupname] = zeros(Int, seqlen)
     end
 
     for interval in intervals
-        arr = covarrays[seqname(interval)]
+        arr = covarrays[groupname(interval)]
         for i in leftposition(interval):rightposition(interval)
             arr[i] += 1
         end
     end
 
     covintervals = GenomicInterval{UInt32}[]
-    for (seqname, arr) in covarrays
+    for (groupname, arr) in covarrays
         i = j = 1
         while i <= length(arr)
             if arr[i] > 0
@@ -75,7 +75,7 @@ function simple_coverage(intervals)
                 while j <= length(arr) && arr[j] == arr[i]
                     j += 1
                 end
-                push!(covintervals, GenomicInterval{UInt32}(seqname, i, j - 1, STRAND_BOTH, arr[i]))
+                push!(covintervals, GenomicInterval{UInt32}(groupname, i, j - 1, STRAND_BOTH, arr[i]))
                 i = j
             else
                 i += 1
@@ -158,7 +158,7 @@ end
 @testset "GenomicInterval" begin
     @testset "Constructor" begin
         i = GenomicInterval("chr1", 10, 20)
-        @test seqname(i) == "chr1"
+        @test groupname(i) == "chr1"
         @test leftposition(i) == 10
         @test rightposition(i) == 20
         @test strand(i) == STRAND_BOTH
@@ -208,7 +208,7 @@ end
     @testset "Constructor" begin
 
         p = GenomicPosition("chr1", 1)
-        @test seqname(p) == "chr1"
+        @test groupname(p) == "chr1"
         @test leftposition(p) == 1
         @test rightposition(p) == 1
         @test position(p) == 1
@@ -524,7 +524,7 @@ end
     buf = IOBuffer()
 
     show(buf, WithoutMetadatata("chr1", 1, 2))
-    @test String(take!(buf)) == "WithoutMetadatata:\n  sequence name: chr1\n  leftmost position: 1\n  rightmost position: 2\n  metadata: nothing"
+    @test String(take!(buf)) == "WithoutMetadatata:\n  group name: chr1\n  leftmost position: 1\n  rightmost position: 2\n  metadata: nothing"
 
 end #testset "Custom Concrete Types"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -199,6 +199,19 @@ end
 
     end
 
+    @testset "precedes" begin
+        interval_a = GenomicInterval("test", 1, 2)
+        interval_b = GenomicInterval("test", 2, 3)
+        interval_c = GenomicInterval("test", 3, 4)
+        interval_d = GenomicInterval("test2", 3, 4)
+
+        @test GenomicFeatures.precedes(interval_a, interval_a) == false
+        @test GenomicFeatures.precedes(interval_a, interval_b) == false
+        @test GenomicFeatures.precedes(interval_a, interval_c) == true
+        @test GenomicFeatures.precedes(interval_c, interval_a) == false
+        @test GenomicFeatures.precedes(interval_a, interval_d) == true
+    end
+
     @test span(GenomicInterval("test", 1, 9)) == length(1:9)
     @test GenomicFeatures.volume(GenomicInterval("test", 1, 9, '?', 2.5)) == length(1:9) * 2.5
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,6 +201,13 @@ end
 
 @testset "GenomicIntervalCollection" begin
 
+    @testset "Constructor" begin
+        @test GenomicIntervalCollection{Int}() == GenomicIntervalCollection{GenomicInterval{Int}}()
+
+        intervals = [GenomicInterval("test", 1, 2)]
+        @test GenomicIntervalCollection{Nothing}(intervals) == GenomicIntervalCollection{GenomicInterval{Nothing}}(intervals)
+    end
+
     @testset "Insertion/Iteration" begin
         n = 100000
         intervals = random_intervals(["one", "two", "three"], 1000000, n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,7 +86,12 @@ function simple_coverage(intervals)
     return covintervals
 end
 
-
+# Used to check show of AbstractGenomicInterval{Nothing}.
+struct WithoutMetadatata <: GenomicFeatures.AbstractGenomicInterval{Nothing}
+    groupname::String
+    first::Int64
+    last::Int64
+end
 
 @testset "GenomicFeatures" begin
 
@@ -462,8 +467,8 @@ end #testset Constructor Conversions
 end
 
 @testset "Mixed types" begin
-    i = GenomicInterval("chr1", 1,4)
 
+    i = GenomicInterval("chr1", 1,4)
     p1 = GenomicPosition("chr1", 2)
     p2 = GenomicPosition("chr1", 5)
     p3 = GenomicPosition("chr2", 5)
@@ -510,6 +515,18 @@ end
     # Check coverage.
     @test [GenomicInterval{UInt32}("chr1",1,1,'.',1), GenomicInterval{UInt32}("chr1",2,2,'.',2), GenomicInterval{UInt32}("chr1",3,4,'.',1)] == collect(coverage(GenomicIntervalCollection([i,p1]))) #TODO: relax comparisons.
 end
+
+
+@testset "Custom Concrete Types" begin
+
+
+
+    buf = IOBuffer()
+
+    show(buf, WithoutMetadatata("chr1", 1, 2))
+    @test String(take!(buf)) == "WithoutMetadatata:\n  sequence name: chr1\n  leftmost position: 1\n  rightmost position: 2\n  metadata: nothing"
+
+end #testset "Custom Concrete Types"
 
 # Include doctests.
 DocMeta.setdocmeta!(GenomicFeatures, :DocTestSetup, :(using GenomicFeatures); recursive=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ import .Utilities: random_intervals
 
 
 # Test that an array of intervals is well ordered
-function is_all_ordered(intervals::Vector{I}) where I <: Interval
+function is_all_ordered(intervals::Vector{I}) where I <: GenomicInterval
     for i = 2:length(intervals)
         if !GenomicFeatures.isordered(intervals[i-1], intervals[i])
             return false
@@ -66,7 +66,7 @@ function simple_coverage(intervals)
         end
     end
 
-    covintervals = Interval{UInt32}[]
+    covintervals = GenomicInterval{UInt32}[]
     for (seqname, arr) in covarrays
         i = j = 1
         while i <= length(arr)
@@ -75,8 +75,7 @@ function simple_coverage(intervals)
                 while j <= length(arr) && arr[j] == arr[i]
                     j += 1
                 end
-                push!(covintervals,
-                      Interval{UInt32}(seqname, i, j - 1, STRAND_BOTH, arr[i]))
+                push!(covintervals, GenomicInterval{UInt32}(seqname, i, j - 1, STRAND_BOTH, arr[i]))
                 i = j
             else
                 i += 1
@@ -151,37 +150,37 @@ end
     end
 end
 
-@testset "Interval" begin
+@testset "GenomicInterval" begin
     @testset "Constructor" begin
-        i = Interval("chr1", 10, 20)
+        i = GenomicInterval("chr1", 10, 20)
         @test seqname(i) == "chr1"
         @test leftposition(i) == 10
         @test rightposition(i) == 20
         @test strand(i) == STRAND_BOTH
-        @test i == Interval("chr1", 10:20)
+        @test i == GenomicInterval("chr1", 10:20)
 
-        i1 = Interval("chr1", 10, 20, '+')
-        i2 = Interval("chr1", 10, 20, STRAND_POS)
+        i1 = GenomicInterval("chr1", 10, 20, '+')
+        i2 = GenomicInterval("chr1", 10, 20, STRAND_POS)
         @test i1 == i2
-        @test i1 == Interval("chr1", 10:20, '+')
+        @test i1 == GenomicInterval("chr1", 10:20, '+')
 
-        i1 = Interval("chr2", 5692667, 5701385, '+',        "SOX11")
-        i2 = Interval("chr2", 5692667, 5701385, STRAND_POS, "SOX11")
+        i1 = GenomicInterval("chr2", 5692667, 5701385, '+',        "SOX11")
+        i2 = GenomicInterval("chr2", 5692667, 5701385, STRAND_POS, "SOX11")
         @test i1 == i2
-        @test i1 == Interval("chr2", 5692667:5701385, '+', "SOX11")
+        @test i1 == GenomicInterval("chr2", 5692667:5701385, '+', "SOX11")
     end
 
     @testset "intervaltype" begin
 
-        intervals = Interval.("test", [1, 2], [1, 2])
-        @test intervals |> eltype |> GenomicFeatures.intervaltype == Interval{Nothing}
+        intervals = GenomicInterval.("test", [1, 2], [1, 2])
+        @test intervals |> eltype |> GenomicFeatures.intervaltype == GenomicInterval{Nothing}
 
-        intervals = Interval.("test", [1, 2], [1, 2], '.', [1.0, 2.0])
-        @test intervals |> eltype |> GenomicFeatures.intervaltype == Interval{Float64}
+        intervals = GenomicInterval.("test", [1, 2], [1, 2], '.', [1.0, 2.0])
+        @test intervals |> eltype |> GenomicFeatures.intervaltype == GenomicInterval{Float64}
 
         # Example `intervaltype` override.
         function GenomicFeatures.intervaltype(::Type{NamedTuple{(:chrom, :left, :right, :value), Tuple{String, Int, Int, T}}}) where T
-            return Interval{T}
+            return GenomicInterval{T}
         end
 
         intervals = NamedTuple.(zip(
@@ -191,36 +190,36 @@ end
             :value .=> [1.0, 2.0],
         ))
 
-        @test intervals |> eltype |> GenomicFeatures.intervaltype == Interval{Float64}
+        @test intervals |> eltype |> GenomicFeatures.intervaltype == GenomicInterval{Float64}
 
     end
 
-    @test span(Interval("test", 1, 9)) == length(1:9)
-    @test GenomicFeatures.volume(Interval("test", 1, 9, '?', 2.5)) == length(1:9) * 2.5
+    @test span(GenomicInterval("test", 1, 9)) == length(1:9)
+    @test GenomicFeatures.volume(GenomicInterval("test", 1, 9, '?', 2.5)) == length(1:9) * 2.5
 
 end
 
-@testset "IntervalCollection" begin
+@testset "GenomicIntervalCollection" begin
 
     @testset "Insertion/Iteration" begin
         n = 100000
         intervals = random_intervals(["one", "two", "three"], 1000000, n)
-        ic = IntervalCollection{Int}()
+        ic = GenomicIntervalCollection{Int}()
 
         @test isempty(ic)
-        @test collect(Interval{Int}, ic) == Interval{Int}[]
+        @test collect(GenomicInterval{Int}, ic) == GenomicInterval{Int}[]
 
         for interval in intervals
             push!(ic, interval)
         end
-        @test is_all_ordered(collect(Interval{Int}, ic))
+        @test is_all_ordered(collect(GenomicInterval{Int}, ic))
     end
 
     @testset "Bulk Insertion" begin
-        i = Interval("chr1", 10, 20, '+', 1)
+        i = GenomicInterval("chr1", 10, 20, '+', 1)
 
         # Test equivalency of shorthand and longhand types.
-        @test IntervalCollection([i]) == IntervalCollection{Int}([i]) == IntervalCollection{Interval{Int}}([i])
+        @test GenomicIntervalCollection([i]) == GenomicIntervalCollection{Int}([i]) == GenomicIntervalCollection{GenomicInterval{Int}}([i])
 
     end
 
@@ -231,8 +230,8 @@ end
         intervals_b = random_intervals(["one", "three", "four"], 1000000, n)
 
         # empty versus empty
-        ic_a = IntervalCollection{Int}()
-        ic_b = IntervalCollection{Int}()
+        ic_a = GenomicIntervalCollection{Int}()
+        ic_b = GenomicIntervalCollection{Int}()
         @test collect(eachoverlap(ic_a, ic_b)) == Any[]
 
         # empty versus non-empty
@@ -248,25 +247,23 @@ end
             push!(ic_b, interval)
         end
 
-        @test sort(collect(eachoverlap(ic_a, ic_b))) ==
-              sort(simple_intersection(intervals_a, intervals_b))
-        @test sort(collect(eachoverlap(ic_a, ic_b, filter=(a,b) -> isodd(first(a))))) ==
-              sort(simple_intersection(intervals_a, intervals_b, filter=(a,b) -> isodd(first(a))))
+        @test sort(collect(eachoverlap(ic_a, ic_b))) == sort(simple_intersection(intervals_a, intervals_b))
+        @test sort(collect(eachoverlap(ic_a, ic_b, filter=(a,b) -> isodd(first(a))))) == sort(simple_intersection(intervals_a, intervals_b, filter=(a,b) -> isodd(first(a))))
 
         # Check hasintersection method.
-        @test hasintersection(Interval("test", 1, 1), IntervalCollection([Interval("test", 1,2)])) == true
-        @test hasintersection(Interval("test", 1, 1), IntervalCollection([Interval("test", 2,2)])) == false
+        @test hasintersection(GenomicInterval("test", 1, 1), GenomicIntervalCollection([GenomicInterval("test", 1,2)])) == true
+        @test hasintersection(GenomicInterval("test", 1, 1), GenomicIntervalCollection([GenomicInterval("test", 2,2)])) == false
 
         # Check hasintersection currying.
-        @test Interval("test", 1, 1) |> hasintersection(IntervalCollection([Interval("test", 1,2)])) == true
-        @test Interval("test", 1, 1) |> hasintersection(IntervalCollection([Interval("test", 2,2)])) == false
+        @test GenomicInterval("test", 1, 1) |> hasintersection(GenomicIntervalCollection([GenomicInterval("test", 1,2)])) == true
+        @test GenomicInterval("test", 1, 1) |> hasintersection(GenomicIntervalCollection([GenomicInterval("test", 2,2)])) == false
     end
 
     @testset "Show" begin
-        ic = IntervalCollection{Int}()
+        ic = GenomicIntervalCollection{Int}()
         show(devnull, ic)
 
-        push!(ic, Interval{Int}("one", 1, 1000, STRAND_POS, 0))
+        push!(ic, GenomicInterval{Int}("one", 1, 1000, STRAND_POS, 0))
         show(devnull, ic)
 
         intervals = random_intervals(["one", "two", "three"], 1000000, 100)
@@ -284,28 +281,28 @@ end
 
 @testset "Constructor Conversions" begin
 
-    i = Interval("chr1", 1, 2, '?', 3)
+    i = GenomicInterval("chr1", 1, 2, '?', 3)
     nt = (chrom="chr1", left=1, right=2, value=3)
 
-    function Base.convert(::Type{Interval{Int}}, nt::NamedTuple)
-        return Interval{Int}(nt.chrom, nt[2], nt[3], '?', nt[4])
+    function Base.convert(::Type{GenomicInterval{Int}}, nt::NamedTuple)
+        return GenomicInterval{Int}(nt.chrom, nt[2], nt[3], '?', nt[4])
     end
 
-    @test i == Interval{Int}(nt)
+    @test i == GenomicInterval{Int}(nt)
 
-    @test IntervalCollection([i]) == IntervalCollection{Int}([nt])
+    @test GenomicIntervalCollection([i]) == GenomicIntervalCollection{Int}([nt])
 
 end #testset Constructor Conversions
 
-@testset "IntervalStream" begin
+@testset "GenomicIntervalStream" begin
     @testset "Intersection" begin
         n = 1000
         Random.seed!(1234)
         intervals_a = random_intervals(["one", "two", "three"], 1000000, n)
         intervals_b = random_intervals(["one", "three", "four"], 1000000, n)
 
-        ic_a = IntervalCollection{Int}()
-        ic_b = IntervalCollection{Int}()
+        ic_a = GenomicIntervalCollection{Int}()
+        ic_b = GenomicIntervalCollection{Int}()
 
         for interval in intervals_a
             push!(ic_a, interval)
@@ -320,50 +317,49 @@ end #testset Constructor Conversions
         @test sort(collect(it)) == sort(simple_intersection(intervals_a, intervals_b))
 
         it = eachoverlap(ic_a, ic_b, isless, filter=(a,b) -> isodd(first(a)))
-        @test sort(collect(it)) ==
-              sort(simple_intersection(intervals_a, intervals_b, filter=(a,b) -> isodd(first(a))))
+        @test sort(collect(it)) == sort(simple_intersection(intervals_a, intervals_b, filter=(a,b) -> isodd(first(a))))
 
         it = eachoverlap(
-            [Interval("a", 1, 100, STRAND_POS, nothing), Interval("c", 1, 100, STRAND_POS, nothing)],
-            [Interval("a", 1, 100, STRAND_POS, nothing), Interval("b", 1, 100, STRAND_POS, nothing)],
+            [GenomicInterval("a", 1, 100, STRAND_POS, nothing), GenomicInterval("c", 1, 100, STRAND_POS, nothing)],
+            [GenomicInterval("a", 1, 100, STRAND_POS, nothing), GenomicInterval("b", 1, 100, STRAND_POS, nothing)],
             isless)
         @test length(collect(it)) == 1
 
         it = eachoverlap(
-            [Interval("c", 1, 100, STRAND_POS, nothing), Interval("d", 1, 100, STRAND_POS, nothing)],
-            [Interval("b", 1, 100, STRAND_POS, nothing), Interval("d", 1, 100, STRAND_POS, nothing)],
+            [GenomicInterval("c", 1, 100, STRAND_POS, nothing), GenomicInterval("d", 1, 100, STRAND_POS, nothing)],
+            [GenomicInterval("b", 1, 100, STRAND_POS, nothing), GenomicInterval("d", 1, 100, STRAND_POS, nothing)],
             isless)
         @test length(collect(it)) == 1
 
         # unsorted streams are not allowed
         @test_throws Exception begin
             it = eachoverlap(
-                [Interval("b", 1, 1000, STRAND_POS, nothing),
-                 Interval("a", 1, 1000, STRAND_POS, nothing)],
-                [Interval("a", 1, 1000, STRAND_POS, nothing),
-                 Interval("b", 1, 1000, STRAND_POS, nothing)], isless)
+                [GenomicInterval("b", 1, 1000, STRAND_POS, nothing),
+                 GenomicInterval("a", 1, 1000, STRAND_POS, nothing)],
+                [GenomicInterval("a", 1, 1000, STRAND_POS, nothing),
+                 GenomicInterval("b", 1, 1000, STRAND_POS, nothing)], isless)
             collect(it)
         end
 
         @test_throws Exception begin
             it = eachoverlap(
-                [Interval("a", 1, 1000, STRAND_POS, nothing),
-                 Interval("a", 500, 1000, STRAND_POS, nothing),
-                 Interval("a", 400, 2000, STRAND_POS, nothing)],
-                [Interval("a", 1, 1000, STRAND_POS, nothing),
-                 Interval("b", 1, 1000, STRAND_POS, nothing)], isless)
+                [GenomicInterval("a", 1, 1000, STRAND_POS, nothing),
+                 GenomicInterval("a", 500, 1000, STRAND_POS, nothing),
+                 GenomicInterval("a", 400, 2000, STRAND_POS, nothing)],
+                [GenomicInterval("a", 1, 1000, STRAND_POS, nothing),
+                 GenomicInterval("b", 1, 1000, STRAND_POS, nothing)], isless)
             collect(it)
         end
     end
 
-    @testset "IntervalStream Intersection" begin
+    @testset "GenomicIntervalStream Intersection" begin
         n = 1000
         Random.seed!(1234)
         intervals_a = random_intervals(["one", "two", "three"], 1000000, n)
         intervals_b = random_intervals(["one", "two", "three"], 1000000, n)
 
-        ic_a = IntervalCollection{Int}()
-        ic_b = IntervalCollection{Int}()
+        ic_a = GenomicIntervalCollection{Int}()
+        ic_b = GenomicIntervalCollection{Int}()
 
         for interval in intervals_a
             push!(ic_a, interval)
@@ -373,18 +369,16 @@ end #testset Constructor Conversions
             push!(ic_b, interval)
         end
 
-        @test sort(collect(eachoverlap(ic_a, ic_b, isless))) ==
-              sort(simple_intersection(intervals_a, intervals_b))
-        @test sort(collect(eachoverlap(ic_a, ic_b, isless, filter=(a,b) -> isodd(first(a))))) ==
-              sort(simple_intersection(intervals_a, intervals_b, filter=(a,b) -> isodd(first(a))))
+        @test sort(collect(eachoverlap(ic_a, ic_b, isless))) == sort(simple_intersection(intervals_a, intervals_b))
+        @test sort(collect(eachoverlap(ic_a, ic_b, isless, filter=(a,b) -> isodd(first(a))))) == sort(simple_intersection(intervals_a, intervals_b, filter=(a,b) -> isodd(first(a))))
     end
 
-    @testset "IntervalStream Coverage" begin
+    @testset "GenomicIntervalStream Coverage" begin
         n = 10000
         Random.seed!(1234)
         intervals = random_intervals(["one", "two", "three"], 1000000, n)
 
-        ic = IntervalCollection{Int}()
+        ic = GenomicIntervalCollection{Int}()
         for interval in intervals
             push!(ic, interval)
         end
@@ -393,47 +387,47 @@ end #testset Constructor Conversions
     end
 
     @testset "eachoverlap" begin
-        i = Interval("chr1", 1, 10)
+        i = GenomicInterval("chr1", 1, 10)
         intervals_a = typeof(i)[]
         @test length(collect(eachoverlap(intervals_a, intervals_a))) == 0
 
-        intervals_a = [Interval("chr1", 1, 10)]
+        intervals_a = [GenomicInterval("chr1", 1, 10)]
         intervals_b = eltype(intervals_a)[]
         @test length(collect(eachoverlap(intervals_a, intervals_b))) == 0
         @test length(collect(eachoverlap(intervals_b, intervals_a))) == 0
 
-        intervals_a = [Interval("chr1", 1, 10)]
+        intervals_a = [GenomicInterval("chr1", 1, 10)]
         @test length(collect(eachoverlap(intervals_a, intervals_a))) == 1
 
-        intervals_a = [Interval("chr1", 1, 10)]
-        intervals_b = [Interval("chr2", 1, 10)]
+        intervals_a = [GenomicInterval("chr1", 1, 10)]
+        intervals_b = [GenomicInterval("chr2", 1, 10)]
         @test length(collect(eachoverlap(intervals_a, intervals_b))) == 0
         @test length(collect(eachoverlap(intervals_b, intervals_a))) == 0
 
-        intervals_a = [Interval("chr1", 1, 10)]
-        intervals_b = [Interval("chr1", 11, 15)]
+        intervals_a = [GenomicInterval("chr1", 1, 10)]
+        intervals_b = [GenomicInterval("chr1", 11, 15)]
         @test length(collect(eachoverlap(intervals_a, intervals_b))) == 0
         @test length(collect(eachoverlap(intervals_b, intervals_a))) == 0
 
-        intervals_a = [Interval("chr1", 11, 15)]
-        intervals_b = [Interval("chr1", 1, 10), Interval("chr1", 12, 13)]
+        intervals_a = [GenomicInterval("chr1", 11, 15)]
+        intervals_b = [GenomicInterval("chr1", 1, 10), GenomicInterval("chr1", 12, 13)]
         @test length(collect(eachoverlap(intervals_a, intervals_b))) == 1
         @test length(collect(eachoverlap(intervals_b, intervals_a))) == 1
 
-        intervals_a = [Interval("chr1", 1, 2), Interval("chr1", 2, 5), Interval("chr2", 1, 10)]
-        intervals_b = [Interval("chr1", 1, 2), Interval("chr1", 2, 3), Interval("chr2", 1, 2)]
+        intervals_a = [GenomicInterval("chr1", 1, 2), GenomicInterval("chr1", 2, 5), GenomicInterval("chr2", 1, 10)]
+        intervals_b = [GenomicInterval("chr1", 1, 2), GenomicInterval("chr1", 2, 3), GenomicInterval("chr2", 1, 2)]
         @test length(collect(eachoverlap(intervals_a, intervals_b))) == 5
         @test length(collect(eachoverlap(intervals_b, intervals_a))) == 5
 
-        intervals_a = [Interval("chr1", 1, 2), Interval("chr1", 3, 5), Interval("chr2", 1, 10)]
+        intervals_a = [GenomicInterval("chr1", 1, 2), GenomicInterval("chr1", 3, 5), GenomicInterval("chr2", 1, 10)]
         @test length(collect(eachoverlap(intervals_a, intervals_a))) == 3
 
         # compare generic and specific eachoverlap methods
-        intervals_a = [Interval("chr1", 1, 2), Interval("chr1", 1, 3), Interval("chr1", 5, 9),
-                       Interval("chr2", 1, 5), Interval("chr2", 6, 6), Interval("chr2", 6, 8)]
+        intervals_a = [GenomicInterval("chr1", 1, 2), GenomicInterval("chr1", 1, 3), GenomicInterval("chr1", 5, 9),
+                       GenomicInterval("chr2", 1, 5), GenomicInterval("chr2", 6, 6), GenomicInterval("chr2", 6, 8)]
         intervals_b = intervals_a
-        ic_a = IntervalCollection(intervals_a)
-        ic_b = IntervalCollection(intervals_b)
+        ic_a = GenomicIntervalCollection(intervals_a)
+        ic_b = GenomicIntervalCollection(intervals_b)
         iter1 = eachoverlap(intervals_a, intervals_b)
         iter2 = eachoverlap(intervals_a, ic_b)
         iter3 = eachoverlap(ic_a, intervals_b)
@@ -441,7 +435,7 @@ end #testset Constructor Conversions
         @test collect(iter1) == collect(iter2) == collect(iter3) == collect(iter4)
 
         # non-overlapping query
-        @test length(collect(eachoverlap(ic_a, Interval("X", 0, 0)))) == 0
+        @test length(collect(eachoverlap(ic_a, GenomicInterval("X", 0, 0)))) == 0
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,6 +171,30 @@ end
         @test i1 == Interval("chr2", 5692667:5701385, '+', "SOX11")
     end
 
+    @testset "intervaltype" begin
+
+        intervals = Interval.("test", [1, 2], [1, 2])
+        @test intervals |> eltype |> GenomicFeatures.intervaltype == Interval{Nothing}
+
+        intervals = Interval.("test", [1, 2], [1, 2], '.', [1.0, 2.0])
+        @test intervals |> eltype |> GenomicFeatures.intervaltype == Interval{Float64}
+
+        # Example `intervaltype` override.
+        function GenomicFeatures.intervaltype(::Type{NamedTuple{(:chrom, :left, :right, :value), Tuple{String, Int, Int, T}}}) where T
+            return Interval{T}
+        end
+
+        intervals = NamedTuple.(zip(
+            :chrom .=> Iterators.repeated("test", 2),
+            :left .=> [1, 2],
+            :right .=> [1, 2],
+            :value .=> [1.0, 2.0],
+        ))
+
+        @test intervals |> eltype |> GenomicFeatures.intervaltype == Interval{Float64}
+
+    end
+
     @test span(Interval("test", 1, 9)) == length(1:9)
     @test GenomicFeatures.volume(Interval("test", 1, 9, '?', 2.5)) == length(1:9) * 2.5
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -199,6 +199,16 @@ end
 
     end
 
+    @testset "baseintervaltype" begin
+        interval = GenomicInterval("test", 1, 2)
+        @test typeof(interval) == GenomicInterval{Nothing}
+        @test GenomicFeatures.baseintervaltype(interval) === GenomicInterval
+
+        interval = GenomicInterval("test", 1, 2, '.', 3.0)
+        @test typeof(interval) == GenomicInterval{Float64}
+        @test GenomicFeatures.baseintervaltype(interval) === GenomicInterval
+    end
+
     @testset "precedes" begin
         interval_a = GenomicInterval("test", 1, 2)
         interval_b = GenomicInterval("test", 2, 3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -199,6 +199,21 @@ end
 
 end
 
+@testset "GenomicPosition" begin
+    @testset "Constructor" begin
+
+        p = GenomicPosition("chr1", 1)
+        @test seqname(p) == "chr1"
+        @test leftposition(p) == 1
+        @test rightposition(p) == 1
+        @test position(p) == 1
+
+        @test GenomicPosition("chr1", 1) == GenomicPosition("chr1", 1:1)
+
+        @test typeof(GenomicFeatures.metadata(GenomicPosition{Float64}("chr1", 1, 9))) == Float64
+    end
+end
+
 @testset "GenomicIntervalCollection" begin
 
     @testset "Constructor" begin
@@ -444,6 +459,56 @@ end #testset Constructor Conversions
         # non-overlapping query
         @test length(collect(eachoverlap(ic_a, GenomicInterval("X", 0, 0)))) == 0
     end
+end
+
+@testset "Mixed types" begin
+    i = GenomicInterval("chr1", 1,4)
+
+    p1 = GenomicPosition("chr1", 2)
+    p2 = GenomicPosition("chr1", 5)
+    p3 = GenomicPosition("chr2", 5)
+
+    # Sorting.
+    @test [i, p1, p2, p3] == sort([p2, p1, p3, i])
+
+    # Push out of order mixed types.
+    col = GenomicIntervalCollection{GenomicFeatures.AbstractGenomicInterval{Nothing}}()
+    push!(col, p2)
+    push!(col, p1)
+    push!(col, p3)
+    push!(col, i)
+
+    @test collect(col) == [i, p1, p2, p3]
+
+    # Bulk insertion of mixed types.
+    col = GenomicIntervalCollection([i, p1, p2, p3])
+
+    @test 4 == length(col)
+
+    # Check overlap.
+    interval_p1_equiv = GenomicInterval("chr1", 2,2)
+    @test true == isoverlapping(i,interval_p1_equiv)
+    @test interval_p1_equiv == p1
+
+    @test true == isoverlapping(i, p1)
+    @test false == isoverlapping(i, p2) == isoverlapping(i, p3)
+
+    # Check eachoverlap.
+    # @test [(i, p1)] == collect(eachoverlap(i, [p1,p2,p3])) #Note: attempts to broadcast i.
+    @test [(i, p1)] == collect(eachoverlap([i], [p1,p2,p3]))
+    @test [(i, p1)] == collect(eachoverlap(GenomicIntervalCollection([i]), GenomicIntervalCollection([p1,p2,p3])))
+    # @test [(p1, i)] == collect(eachoverlap([p1,p2,p3], i)) #Note: attempts to broadcast i.
+    @test [(p1, i)] == collect(eachoverlap([p1,p2,p3], [i]))
+    @test [(p1, i)] == collect(eachoverlap(GenomicIntervalCollection([p1,p2,p3]), GenomicIntervalCollection([i])))
+
+    # Pushing mixed types to Queue.
+    @test [(i, p1), (p1,p1)] == collect(eachoverlap([i, p1], [p1,p2,p3]))
+    @test [(i, p1), (p1,p1)] == collect(eachoverlap(GenomicIntervalCollection([i,p1]), GenomicIntervalCollection([p1,p2,p3])))
+    @test [(p1, i), (p1,p1)] == collect(eachoverlap([p1,p2,p3], [i, p1]))
+    @test [(p1, i), (p1,p1)] == collect(eachoverlap(GenomicIntervalCollection([p1,p2,p3]), GenomicIntervalCollection([i,p1])))
+
+    # Check coverage.
+    @test [GenomicInterval{UInt32}("chr1",1,1,'.',1), GenomicInterval{UInt32}("chr1",2,2,'.',2), GenomicInterval{UInt32}("chr1",3,4,'.',1)] == collect(coverage(GenomicIntervalCollection([i,p1]))) #TODO: relax comparisons.
 end
 
 # Include doctests.


### PR DESCRIPTION
This PR refactors `GenomicFeatures` to make use of abstract types.

This PR contains the following breaking changes.
- The `Interval` type is renamed `GenomicInterval` and now subtypes `AbstractGenomicInterval`.
- The  `IntervalCollection` is now `GenomicIntervalCollection`, and the element type of the collection is now the `AbstractGenomicInterval` instead of the interval's metadata type.
- Intervals are now grouped by the more generic `groupname` instead of `seqname`.