### PR TITLE
Remove unused parameter in (==) extended method

### DIFF
--- a/src/position.jl
+++ b/src/position.jl
@@ -54,7 +54,7 @@ function Base.show(io::IO, p::GenomicPosition)
     end
 end
 
-function Base.:(==)(a::GenomicPosition, b::GenomicPosition) where T
+function Base.:(==)(a::GenomicPosition, b::GenomicPosition)
     return groupname(a) == groupname(b) &&
            position(a)  == position(b) &&
            metadata(a)  == metadata(b)


### PR DESCRIPTION
This is a simple change that avoids a warning about an unused parameter where clause.